### PR TITLE
Fix return type of graphs methods by edge parameterization  

### DIFF
--- a/app/src/main/kotlin/model/DirectedGraph.kt
+++ b/app/src/main/kotlin/model/DirectedGraph.kt
@@ -1,24 +1,23 @@
 package model
 
-import model.abstractGraph.Edge
 import model.abstractGraph.Graph
 import model.abstractGraph.Vertex
 import model.edges.DirectedEdge
 
-open class DirectedGraph<D> : Graph<D>() {
-    override fun addEdge(vertex1: Vertex<D>, vertex2: Vertex<D>): DirectedEdge<D> {
+open class DirectedGraph<D, E : DirectedEdge<D>> : Graph<D, E>() {
+    override fun addEdge(vertex1: Vertex<D>, vertex2: Vertex<D>): E {
         if (vertex1 == vertex2) throw IllegalArgumentException("Vertices are the same")
         if (vertex1 !in adjacencyMap.keys || vertex2 !in adjacencyMap.keys)
             throw IllegalArgumentException("Vertex1 or vertex2 are not in the graph")
 
-        val newEdge = DirectedEdge(vertex1, vertex2)
+        val newEdge = DirectedEdge(vertex1, vertex2) as E
         edges.add(newEdge)
         adjacencyMap[vertex1]?.add(vertex2)
 
         return newEdge
     }
 
-    override fun removeEdge(edgeToRemove: Edge<D>): Edge<D> {
+    override fun removeEdge(edgeToRemove: E): E {
         if (edgeToRemove !in edges) throw IllegalArgumentException("Edge is not in the graph")
 
         val vertex1 = edgeToRemove.vertex1

--- a/app/src/main/kotlin/model/DirectedGraph.kt
+++ b/app/src/main/kotlin/model/DirectedGraph.kt
@@ -1,31 +1,6 @@
 package model
 
-import model.abstractGraph.Graph
-import model.abstractGraph.Vertex
 import model.edges.DirectedEdge
+import model.internalGraphs._DirectedGraph
 
-open class DirectedGraph<D, E : DirectedEdge<D>> : Graph<D, E>() {
-    override fun addEdge(vertex1: Vertex<D>, vertex2: Vertex<D>): E {
-        if (vertex1 == vertex2) throw IllegalArgumentException("Vertices are the same")
-        if (vertex1 !in adjacencyMap.keys || vertex2 !in adjacencyMap.keys)
-            throw IllegalArgumentException("Vertex1 or vertex2 are not in the graph")
-
-        val newEdge = DirectedEdge(vertex1, vertex2) as E
-        edges.add(newEdge)
-        adjacencyMap[vertex1]?.add(vertex2)
-
-        return newEdge
-    }
-
-    override fun removeEdge(edgeToRemove: E): E {
-        if (edgeToRemove !in edges) throw IllegalArgumentException("Edge is not in the graph")
-
-        val vertex1 = edgeToRemove.vertex1
-        val vertex2 = edgeToRemove.vertex2
-
-        adjacencyMap[vertex1]?.remove(vertex2)
-        edges.remove(edgeToRemove)
-
-        return edgeToRemove
-    }
-}
+class DirectedGraph<D> : _DirectedGraph<D, DirectedEdge<D>>()

--- a/app/src/main/kotlin/model/UndirectedGraph.kt
+++ b/app/src/main/kotlin/model/UndirectedGraph.kt
@@ -1,33 +1,6 @@
 package model
 
-import model.abstractGraph.Graph
-import model.abstractGraph.Vertex
 import model.edges.UndirectedEdge
+import model.internalGraphs._UndirectedGraph
 
-open class UndirectedGraph<D, E : UndirectedEdge<D>> : Graph<D, E>() {
-    override fun addEdge(vertex1: Vertex<D>, vertex2: Vertex<D>): E {
-        if (vertex1 == vertex2) throw IllegalArgumentException("Vertices are the same")
-        if (vertex1 !in adjacencyMap.keys || vertex2 !in adjacencyMap.keys)
-            throw IllegalArgumentException("Vertex1 or vertex2 are not in the graph")
-
-        val newEdge = UndirectedEdge(vertex1, vertex2) as E
-        edges.add(newEdge)
-        adjacencyMap[vertex1]?.add(vertex2)
-        adjacencyMap[vertex2]?.add(vertex1)
-
-        return newEdge
-    }
-
-    override fun removeEdge(edgeToRemove: E): E {
-        if (edgeToRemove !in edges) throw IllegalArgumentException("Edge is not in the graph")
-
-        val vertex1 = edgeToRemove.vertex1
-        val vertex2 = edgeToRemove.vertex2
-
-        adjacencyMap[vertex1]?.remove(vertex2)
-        adjacencyMap[vertex2]?.remove(vertex1)
-        edges.remove(edgeToRemove)
-
-        return edgeToRemove
-    }
-}
+class UndirectedGraph<D> : _UndirectedGraph<D, UndirectedEdge<D>>()

--- a/app/src/main/kotlin/model/UndirectedGraph.kt
+++ b/app/src/main/kotlin/model/UndirectedGraph.kt
@@ -1,17 +1,16 @@
 package model
 
-import model.abstractGraph.Edge
 import model.abstractGraph.Graph
 import model.abstractGraph.Vertex
 import model.edges.UndirectedEdge
 
-open class UndirectedGraph<D> : Graph<D>() {
-    override fun addEdge(vertex1: Vertex<D>, vertex2: Vertex<D>): UndirectedEdge<D> {
+open class UndirectedGraph<D, E : UndirectedEdge<D>> : Graph<D, E>() {
+    override fun addEdge(vertex1: Vertex<D>, vertex2: Vertex<D>): E {
         if (vertex1 == vertex2) throw IllegalArgumentException("Vertices are the same")
         if (vertex1 !in adjacencyMap.keys || vertex2 !in adjacencyMap.keys)
             throw IllegalArgumentException("Vertex1 or vertex2 are not in the graph")
 
-        val newEdge = UndirectedEdge(vertex1, vertex2)
+        val newEdge = UndirectedEdge(vertex1, vertex2) as E
         edges.add(newEdge)
         adjacencyMap[vertex1]?.add(vertex2)
         adjacencyMap[vertex2]?.add(vertex1)
@@ -19,7 +18,7 @@ open class UndirectedGraph<D> : Graph<D>() {
         return newEdge
     }
 
-    override fun removeEdge(edgeToRemove: Edge<D>): Edge<D> {
+    override fun removeEdge(edgeToRemove: E): E {
         if (edgeToRemove !in edges) throw IllegalArgumentException("Edge is not in the graph")
 
         val vertex1 = edgeToRemove.vertex1

--- a/app/src/main/kotlin/model/WeightedDirectedGraph.kt
+++ b/app/src/main/kotlin/model/WeightedDirectedGraph.kt
@@ -1,23 +1,6 @@
 package model
 
-import model.abstractGraph.Vertex
 import model.edges.WeightedDirectedEdge
+import model.internalGraphs._WeightedDirectedGraph
 
-class WeightedDirectedGraph<D, E : WeightedDirectedEdge<D>> : DirectedGraph<D, E>() {
-    fun addEdge(vertex1: Vertex<D>, vertex2: Vertex<D>, weight: Int): E {
-        if (vertex1 == vertex2) throw IllegalArgumentException("Vertices are the same")
-        if (vertex1 !in adjacencyMap.keys || vertex2 !in adjacencyMap.keys)
-            throw IllegalArgumentException("Vertex1 or vertex2 are not in the graph")
-
-        val newEdge = WeightedDirectedEdge(vertex1, vertex2, weight) as E
-        edges.add(newEdge)
-        adjacencyMap[vertex1]?.add(vertex2)
-
-        return newEdge
-    }
-
-    /*
-     * In case weight is not passed, set it to default value = 1
-     */
-    override fun addEdge(vertex1: Vertex<D>, vertex2: Vertex<D>) = addEdge(vertex1, vertex2, 1)
-}
+class WeightedDirectedGraph<D> : _WeightedDirectedGraph<D, WeightedDirectedEdge<D>>()

--- a/app/src/main/kotlin/model/WeightedDirectedGraph.kt
+++ b/app/src/main/kotlin/model/WeightedDirectedGraph.kt
@@ -3,13 +3,13 @@ package model
 import model.abstractGraph.Vertex
 import model.edges.WeightedDirectedEdge
 
-class WeightedDirectedGraph<D> : DirectedGraph<D>() {
-    fun addEdge(vertex1: Vertex<D>, vertex2: Vertex<D>, weight: Int): WeightedDirectedEdge<D> {
+class WeightedDirectedGraph<D, E : WeightedDirectedEdge<D>> : DirectedGraph<D, E>() {
+    fun addEdge(vertex1: Vertex<D>, vertex2: Vertex<D>, weight: Int): E {
         if (vertex1 == vertex2) throw IllegalArgumentException("Vertices are the same")
         if (vertex1 !in adjacencyMap.keys || vertex2 !in adjacencyMap.keys)
             throw IllegalArgumentException("Vertex1 or vertex2 are not in the graph")
 
-        val newEdge = WeightedDirectedEdge(vertex1, vertex2, weight)
+        val newEdge = WeightedDirectedEdge(vertex1, vertex2, weight) as E
         edges.add(newEdge)
         adjacencyMap[vertex1]?.add(vertex2)
 

--- a/app/src/main/kotlin/model/WeightedUndirectedGraph.kt
+++ b/app/src/main/kotlin/model/WeightedUndirectedGraph.kt
@@ -3,13 +3,13 @@ package model
 import model.abstractGraph.Vertex
 import model.edges.WeightedUndirectedEdge
 
-class WeightedUndirectedGraph<D> : UndirectedGraph<D>() {
-    fun addEdge(vertex1: Vertex<D>, vertex2: Vertex<D>, weight: Int): WeightedUndirectedEdge<D> {
+class WeightedUndirectedGraph<D, E : WeightedUndirectedEdge<D>> : UndirectedGraph<D, E>() {
+    fun addEdge(vertex1: Vertex<D>, vertex2: Vertex<D>, weight: Int): E {
         if (vertex1 == vertex2) throw IllegalArgumentException("Vertices are the same")
         if (vertex1 !in adjacencyMap.keys || vertex2 !in adjacencyMap.keys)
             throw IllegalArgumentException("Vertex1 or vertex2 are not in the graph")
 
-        val newEdge = WeightedUndirectedEdge(vertex1, vertex2, weight)
+        val newEdge = WeightedUndirectedEdge(vertex1, vertex2, weight) as E
         edges.add(newEdge)
         adjacencyMap[vertex1]?.add(vertex2)
         adjacencyMap[vertex2]?.add(vertex1)

--- a/app/src/main/kotlin/model/WeightedUndirectedGraph.kt
+++ b/app/src/main/kotlin/model/WeightedUndirectedGraph.kt
@@ -1,24 +1,6 @@
 package model
 
-import model.abstractGraph.Vertex
 import model.edges.WeightedUndirectedEdge
+import model.internalGraphs._WeightedUndirectedGraph
 
-class WeightedUndirectedGraph<D, E : WeightedUndirectedEdge<D>> : UndirectedGraph<D, E>() {
-    fun addEdge(vertex1: Vertex<D>, vertex2: Vertex<D>, weight: Int): E {
-        if (vertex1 == vertex2) throw IllegalArgumentException("Vertices are the same")
-        if (vertex1 !in adjacencyMap.keys || vertex2 !in adjacencyMap.keys)
-            throw IllegalArgumentException("Vertex1 or vertex2 are not in the graph")
-
-        val newEdge = WeightedUndirectedEdge(vertex1, vertex2, weight) as E
-        edges.add(newEdge)
-        adjacencyMap[vertex1]?.add(vertex2)
-        adjacencyMap[vertex2]?.add(vertex1)
-
-        return newEdge
-    }
-
-    /*
-     * In case weight is not passed, set it to default value = 1
-     */
-    override fun addEdge(vertex1: Vertex<D>, vertex2: Vertex<D>) = addEdge(vertex1, vertex2, 1)
-}
+class WeightedUndirectedGraph<D> : _WeightedUndirectedGraph<D, WeightedUndirectedEdge<D>>()

--- a/app/src/main/kotlin/model/abstractGraph/Edge.kt
+++ b/app/src/main/kotlin/model/abstractGraph/Edge.kt
@@ -1,6 +1,6 @@
 package model.abstractGraph
 
-interface Edge<D> {
-    val vertex1: Vertex<D>
-    val vertex2: Vertex<D>
+abstract class Edge<D> {
+    abstract val vertex1: Vertex<D>
+    abstract val vertex2: Vertex<D>
 }

--- a/app/src/main/kotlin/model/abstractGraph/Graph.kt
+++ b/app/src/main/kotlin/model/abstractGraph/Graph.kt
@@ -1,8 +1,8 @@
 package model.abstractGraph
 
-abstract class Graph<D> {
+abstract class Graph<D, E : Edge<D>> {
     protected val adjacencyMap: MutableMap<Vertex<D>, ArrayList<Vertex<D>>> = mutableMapOf()
-    protected val edges: MutableSet<Edge<D>> = mutableSetOf()
+    protected val edges: MutableSet<E> = mutableSetOf()
     private var currentId = 0uL
 
     fun addVertex(data: D): Vertex<D> {
@@ -22,9 +22,9 @@ abstract class Graph<D> {
         return vertexToDelete
     }
 
-    abstract fun addEdge(vertex1: Vertex<D>, vertex2: Vertex<D>): Edge<D>
+    abstract fun addEdge(vertex1: Vertex<D>, vertex2: Vertex<D>): E
 
-    abstract fun removeEdge(edgeToRemove: Edge<D>): Edge<D>
+    abstract fun removeEdge(edgeToRemove: E): E
 
     fun getVertices() = adjacencyMap.keys.toList()
 

--- a/app/src/main/kotlin/model/edges/DirectedEdge.kt
+++ b/app/src/main/kotlin/model/edges/DirectedEdge.kt
@@ -3,4 +3,4 @@ package model.edges
 import model.abstractGraph.Edge
 import model.abstractGraph.Vertex
 
-open class DirectedEdge<D>(override val vertex1: Vertex<D>, override val vertex2: Vertex<D>) : Edge<D>
+open class DirectedEdge<D>(override val vertex1: Vertex<D>, override val vertex2: Vertex<D>) : Edge<D>()

--- a/app/src/main/kotlin/model/edges/UndirectedEdge.kt
+++ b/app/src/main/kotlin/model/edges/UndirectedEdge.kt
@@ -3,4 +3,4 @@ package model.edges
 import model.abstractGraph.Edge
 import model.abstractGraph.Vertex
 
-open class UndirectedEdge<D>(override val vertex1: Vertex<D>, override val vertex2: Vertex<D>) : Edge<D>
+open class UndirectedEdge<D>(override val vertex1: Vertex<D>, override val vertex2: Vertex<D>) : Edge<D>()

--- a/app/src/main/kotlin/model/internalGraphs/_DirectedGraph.kt
+++ b/app/src/main/kotlin/model/internalGraphs/_DirectedGraph.kt
@@ -1,0 +1,31 @@
+package model.internalGraphs
+
+import model.abstractGraph.Graph
+import model.abstractGraph.Vertex
+import model.edges.DirectedEdge
+
+abstract class _DirectedGraph<D, E : DirectedEdge<D>> : Graph<D, E>() {
+    override fun addEdge(vertex1: Vertex<D>, vertex2: Vertex<D>): E {
+        if (vertex1 == vertex2) throw IllegalArgumentException("Vertices are the same")
+        if (vertex1 !in adjacencyMap.keys || vertex2 !in adjacencyMap.keys)
+            throw IllegalArgumentException("Vertex1 or vertex2 are not in the graph")
+
+        val newEdge = DirectedEdge(vertex1, vertex2) as E
+        edges.add(newEdge)
+        adjacencyMap[vertex1]?.add(vertex2)
+
+        return newEdge
+    }
+
+    override fun removeEdge(edgeToRemove: E): E {
+        if (edgeToRemove !in edges) throw IllegalArgumentException("Edge is not in the graph")
+
+        val vertex1 = edgeToRemove.vertex1
+        val vertex2 = edgeToRemove.vertex2
+
+        adjacencyMap[vertex1]?.remove(vertex2)
+        edges.remove(edgeToRemove)
+
+        return edgeToRemove
+    }
+}

--- a/app/src/main/kotlin/model/internalGraphs/_UndirectedGraph.kt
+++ b/app/src/main/kotlin/model/internalGraphs/_UndirectedGraph.kt
@@ -1,0 +1,33 @@
+package model.internalGraphs
+
+import model.abstractGraph.Graph
+import model.abstractGraph.Vertex
+import model.edges.UndirectedEdge
+
+abstract class _UndirectedGraph<D, E : UndirectedEdge<D>> : Graph<D, E>() {
+    override fun addEdge(vertex1: Vertex<D>, vertex2: Vertex<D>): E {
+        if (vertex1 == vertex2) throw IllegalArgumentException("Vertices are the same")
+        if (vertex1 !in adjacencyMap.keys || vertex2 !in adjacencyMap.keys)
+            throw IllegalArgumentException("Vertex1 or vertex2 are not in the graph")
+
+        val newEdge = UndirectedEdge(vertex1, vertex2) as E
+        edges.add(newEdge)
+        adjacencyMap[vertex1]?.add(vertex2)
+        adjacencyMap[vertex2]?.add(vertex1)
+
+        return newEdge
+    }
+
+    override fun removeEdge(edgeToRemove: E): E {
+        if (edgeToRemove !in edges) throw IllegalArgumentException("Edge is not in the graph")
+
+        val vertex1 = edgeToRemove.vertex1
+        val vertex2 = edgeToRemove.vertex2
+
+        adjacencyMap[vertex1]?.remove(vertex2)
+        adjacencyMap[vertex2]?.remove(vertex1)
+        edges.remove(edgeToRemove)
+
+        return edgeToRemove
+    }
+}

--- a/app/src/main/kotlin/model/internalGraphs/_WeightedDirectedGraph.kt
+++ b/app/src/main/kotlin/model/internalGraphs/_WeightedDirectedGraph.kt
@@ -1,0 +1,23 @@
+package model.internalGraphs
+
+import model.abstractGraph.Vertex
+import model.edges.WeightedDirectedEdge
+
+abstract class _WeightedDirectedGraph<D, E : WeightedDirectedEdge<D>> : _DirectedGraph<D, E>() {
+    fun addEdge(vertex1: Vertex<D>, vertex2: Vertex<D>, weight: Int): E {
+        if (vertex1 == vertex2) throw IllegalArgumentException("Vertices are the same")
+        if (vertex1 !in adjacencyMap.keys || vertex2 !in adjacencyMap.keys)
+            throw IllegalArgumentException("Vertex1 or vertex2 are not in the graph")
+
+        val newEdge = WeightedDirectedEdge(vertex1, vertex2, weight) as E
+        edges.add(newEdge)
+        adjacencyMap[vertex1]?.add(vertex2)
+
+        return newEdge
+    }
+
+    /*
+     * In case weight is not passed, set it to default value = 1
+     */
+    override fun addEdge(vertex1: Vertex<D>, vertex2: Vertex<D>) = addEdge(vertex1, vertex2, 1)
+}

--- a/app/src/main/kotlin/model/internalGraphs/_WeightedUndirectedGraph.kt
+++ b/app/src/main/kotlin/model/internalGraphs/_WeightedUndirectedGraph.kt
@@ -1,0 +1,24 @@
+package model.internalGraphs
+
+import model.abstractGraph.Vertex
+import model.edges.WeightedUndirectedEdge
+
+abstract class _WeightedUndirectedGraph<D, E : WeightedUndirectedEdge<D>> : _UndirectedGraph<D, E>() {
+    fun addEdge(vertex1: Vertex<D>, vertex2: Vertex<D>, weight: Int): E {
+        if (vertex1 == vertex2) throw IllegalArgumentException("Vertices are the same")
+        if (vertex1 !in adjacencyMap.keys || vertex2 !in adjacencyMap.keys)
+            throw IllegalArgumentException("Vertex1 or vertex2 are not in the graph")
+
+        val newEdge = WeightedUndirectedEdge(vertex1, vertex2, weight) as E
+        edges.add(newEdge)
+        adjacencyMap[vertex1]?.add(vertex2)
+        adjacencyMap[vertex2]?.add(vertex1)
+
+        return newEdge
+    }
+
+    /*
+     * In case weight is not passed, set it to default value = 1
+     */
+    override fun addEdge(vertex1: Vertex<D>, vertex2: Vertex<D>) = addEdge(vertex1, vertex2, 1)
+}


### PR DESCRIPTION
Change Edge to abstract class. Change model file structure.

Add edge generic types to graphs. Add graph wrap classes so that edge types don't have to be passed to graphs.

