### PR TITLE
Fix id fragmentation in removeVertex method

### DIFF
--- a/app/src/main/kotlin/model/abstractGraph/Edge.kt
+++ b/app/src/main/kotlin/model/abstractGraph/Edge.kt
@@ -3,4 +3,6 @@ package model.abstractGraph
 abstract class Edge<D> {
     abstract val vertex1: Vertex<D>
     abstract val vertex2: Vertex<D>
+
+    fun isIncident(vertex: Vertex<D>) = (vertex1 == vertex || vertex2 == vertex)
 }

--- a/app/src/main/kotlin/model/abstractGraph/Graph.kt
+++ b/app/src/main/kotlin/model/abstractGraph/Graph.kt
@@ -12,18 +12,18 @@ abstract class Graph<D, E : Edge<D>> {
         return newVertex
     }
 
-    fun deleteVertex(vertexToDelete: Vertex<D>): Vertex<D> {
+    fun removeVertex(vertexToRemove: Vertex<D>): Vertex<D> {
         val adjacentVertices =
-            adjacencyMap[vertexToDelete] ?: throw IllegalArgumentException("Vertex is not in the graph")
+            adjacencyMap[vertexToRemove] ?: throw IllegalArgumentException("Vertex is not in the graph")
 
-        for (adjacentVertex in adjacentVertices) adjacencyMap[adjacentVertex]?.remove(vertexToDelete)
-        adjacencyMap.remove(vertexToDelete)
+        for (adjacentVertex in adjacentVertices) adjacencyMap[adjacentVertex]?.remove(vertexToRemove)
+        adjacencyMap.remove(vertexToRemove)
 
         for (edge in getEdges()) {
-            if (edge.isIncident(vertexToDelete)) edges.remove(edge)
+            if (edge.isIncident(vertexToRemove)) edges.remove(edge)
         }
 
-        return vertexToDelete
+        return vertexToRemove
     }
 
     abstract fun addEdge(vertex1: Vertex<D>, vertex2: Vertex<D>): E

--- a/app/src/main/kotlin/model/abstractGraph/Graph.kt
+++ b/app/src/main/kotlin/model/abstractGraph/Graph.kt
@@ -19,6 +19,10 @@ abstract class Graph<D, E : Edge<D>> {
         for (adjacentVertex in adjacentVertices) adjacencyMap[adjacentVertex]?.remove(vertexToDelete)
         adjacencyMap.remove(vertexToDelete)
 
+        for (edge in getEdges()) {
+            if (edge.isIncident(vertexToDelete)) edges.remove(edge)
+        }
+
         return vertexToDelete
     }
 

--- a/app/src/main/kotlin/model/internalGraphs/_WeightedDirectedGraph.kt
+++ b/app/src/main/kotlin/model/internalGraphs/_WeightedDirectedGraph.kt
@@ -1,8 +1,8 @@
 package model.internalGraphs
 
+import java.util.*
 import model.abstractGraph.Vertex
 import model.edges.WeightedDirectedEdge
-import java.util.*
 
 abstract class _WeightedDirectedGraph<D, E : WeightedDirectedEdge<D>> : _DirectedGraph<D, E>() {
     fun addEdge(vertex1: Vertex<D>, vertex2: Vertex<D>, weight: Int): E {
@@ -24,7 +24,7 @@ abstract class _WeightedDirectedGraph<D, E : WeightedDirectedEdge<D>> : _Directe
 
     fun findShortestPathDijkstra(srcVertex: Vertex<D>, destVertex: Vertex<D>): List<Pair<Vertex<D>, E>> {
         val vertices = getVertices()
-        val distanceMap = mutableMapOf<Vertex<D>, Int>().withDefault{ Int.MAX_VALUE }
+        val distanceMap = mutableMapOf<Vertex<D>, Int>().withDefault { Int.MAX_VALUE }
         val predecessorMap = mutableMapOf<Vertex<D>, Vertex<D>?>()
         val priorityQueue = PriorityQueue<Pair<Vertex<D>, Int>>(compareBy { it.second }).apply { add(destVertex to 0) }
         val visited = mutableSetOf<Pair<Vertex<D>, Int>>()
@@ -34,7 +34,7 @@ abstract class _WeightedDirectedGraph<D, E : WeightedDirectedEdge<D>> : _Directe
         while (priorityQueue.isNotEmpty()) {
             val (node, currentDistance) = priorityQueue.poll()
             if (visited.add(node to currentDistance)) {
-                adjacencyMap[node]?.forEach{ adjacent ->
+                adjacencyMap[node]?.forEach { adjacent ->
                     val currentEdge = edges.find { it.vertex1 == adjacent }
                     currentEdge?.let {
                         val totalDist = currentDistance + it.weight
@@ -51,17 +51,18 @@ abstract class _WeightedDirectedGraph<D, E : WeightedDirectedEdge<D>> : _Directe
         // Reconstruct the path from srcVertex to destVertex
         val path: MutableList<Pair<Vertex<D>, E>> = mutableListOf()
         var currentVertex = destVertex
-            while (currentVertex != srcVertex) {
-                val predecessor = predecessorMap[currentVertex]
-                if (predecessor == null) {
-                    // If no path exists
-                    return emptyList()
-                }
-                if (edges.find { it.vertex1 == predecessor && it.vertex2 == currentVertex } == null) {
-                    throw IllegalArgumentException("Edge is not in the graph, path cannot be reconstructed.")
-                }
-                path.add(Pair(currentVertex, edges.find { it.vertex1 == predecessor && it.vertex2 == currentVertex })
-                        as Pair<Vertex<D>, E>)
+        while (currentVertex != srcVertex) {
+            val predecessor = predecessorMap[currentVertex]
+            if (predecessor == null) {
+                // If no path exists
+                return emptyList()
+            }
+            if (edges.find { it.vertex1 == predecessor && it.vertex2 == currentVertex } == null) {
+                throw IllegalArgumentException("Edge is not in the graph, path cannot be reconstructed.")
+            }
+            path.add(
+                Pair(currentVertex, edges.find { it.vertex1 == predecessor && it.vertex2 == currentVertex })
+                    as Pair<Vertex<D>, E>)
             currentVertex = predecessor
         }
         return path.reversed()

--- a/app/src/main/kotlin/model/internalGraphs/_WeightedUndirectedGraph.kt
+++ b/app/src/main/kotlin/model/internalGraphs/_WeightedUndirectedGraph.kt
@@ -1,8 +1,8 @@
 package model.internalGraphs
 
+import java.util.*
 import model.abstractGraph.Vertex
 import model.edges.WeightedUndirectedEdge
-import java.util.*
 
 abstract class _WeightedUndirectedGraph<D, E : WeightedUndirectedEdge<D>> : _UndirectedGraph<D, E>() {
     fun addEdge(vertex1: Vertex<D>, vertex2: Vertex<D>, weight: Int): E {
@@ -36,8 +36,11 @@ abstract class _WeightedUndirectedGraph<D, E : WeightedUndirectedEdge<D>> : _Und
             val (node, currentDistance) = priorityQueue.poll()
             if (visited.add(node to currentDistance)) {
                 adjacencyMap[node]?.forEach { adjacent ->
-                    val currentEdge = edges.find { (it.vertex1 == adjacent && it.vertex2 == node) ||
-                            (it.vertex1 == node && it.vertex2 == adjacent) }
+                    val currentEdge =
+                        edges.find {
+                            (it.vertex1 == adjacent && it.vertex2 == node) ||
+                                (it.vertex1 == node && it.vertex2 == adjacent)
+                        }
                     currentEdge?.let {
                         val totalDist = currentDistance + currentEdge.weight
                         if (totalDist < distanceMap.getValue(adjacent)) {
@@ -59,12 +62,20 @@ abstract class _WeightedUndirectedGraph<D, E : WeightedUndirectedEdge<D>> : _Und
                 // If no path exists
                 return emptyList()
             }
-            if (edges.find { it.vertex1 == predecessor && it.vertex2 == currentVertex ||
-                        it.vertex2 == predecessor && it.vertex1 == currentVertex } == null) {
+            if (edges.find {
+                it.vertex1 == predecessor && it.vertex2 == currentVertex ||
+                    it.vertex2 == predecessor && it.vertex1 == currentVertex
+            } == null) {
                 throw IllegalArgumentException("Edge is not in the graph, path cannot be reconstructed.")
             }
-            path.add(Pair(currentVertex, edges.find { it.vertex1 == predecessor && it.vertex2 == currentVertex  ||
-                    it.vertex2 == predecessor && it.vertex1 == currentVertex}) as Pair<Vertex<D>, E>)
+            path.add(
+                Pair(
+                    currentVertex,
+                    edges.find {
+                        it.vertex1 == predecessor && it.vertex2 == currentVertex ||
+                            it.vertex2 == predecessor && it.vertex1 == currentVertex
+                    })
+                    as Pair<Vertex<D>, E>)
             currentVertex = predecessor
         }
         return path.reversed()


### PR DESCRIPTION
Add isIncident method to abstract edge class.

Fix removal of incident edges after vertex removal.

Add private method that removes vertex from all adjacent vertices and incident edges. 

Add private method that changes last added vertex's id to removed vertex's id by coping removed vertex's id and last added vertex's data and creating new vertex.  