### PR TITLE
Localize exceptions and apply same code style for them

### DIFF
--- a/app/src/main/kotlin/model/abstractGraph/Graph.kt
+++ b/app/src/main/kotlin/model/abstractGraph/Graph.kt
@@ -25,24 +25,21 @@ abstract class Graph<D, E : Edge<D>> {
 
     abstract fun removeEdge(edgeToRemove: E): E
 
-    fun getVertices() = adjacencyMap.keys.toList()
-
-    fun getEdges() = edges.toList()
-
     private fun fixIdFragmentation(vertexToRemove: Vertex<D>) {
         currentId--
-        val lastAddedVertex =
-            getVertices().find { it.id == currentId } ?: throw NoSuchElementException("No vertex with id $currentId")
+        val lastAddedVertex = getVertices().find { it.id == currentId }
+            ?: throw NoSuchElementException("Vertex with id $currentId is not present in the adjacency map.")
 
-        val copyOfLastAddedVertex = Vertex<D>(vertexToRemove.id, lastAddedVertex.data)
-        adjacencyMap[copyOfLastAddedVertex] =
-            adjacencyMap[lastAddedVertex] ?: throw NoSuchElementException("No vertex with id $currentId")
+        val copyOfLastAddedVertex = Vertex(vertexToRemove.id, lastAddedVertex.data)
 
-        val adjacentVertices =
-            adjacencyMap[copyOfLastAddedVertex] ?: throw NoSuchElementException("No vertex with id $currentId")
+        adjacencyMap[copyOfLastAddedVertex] = adjacencyMap[lastAddedVertex]
+            ?: throw NoSuchElementException("Vertex with id ${lastAddedVertex.id} is not present in the adjacency map.")
+
+        val adjacentVertices = adjacencyMap[copyOfLastAddedVertex]
+            ?: throw NoSuchElementException("Vertex with id ${copyOfLastAddedVertex.id} is not present in the adjacency map.")
 
         for (adjacentVertex in adjacentVertices) {
-            if (adjacencyMap[adjacentVertex]?.remove(lastAddedVertex) ?: false) {
+            if (adjacencyMap[adjacentVertex]?.remove(lastAddedVertex) == true) {
                 adjacencyMap[adjacentVertex]?.add(copyOfLastAddedVertex)
             }
         }
@@ -52,8 +49,8 @@ abstract class Graph<D, E : Edge<D>> {
     }
 
     private fun removeVertexFromIncidentEdgesAndAdjacentVerticesMapValues(vertexToRemove: Vertex<D>) {
-        val adjacentVertices =
-            adjacencyMap[vertexToRemove] ?: throw NoSuchElementException("Vertex is not in the graph")
+        val adjacentVertices = adjacencyMap[vertexToRemove]
+            ?: throw NoSuchElementException("Vertex with id ${vertexToRemove.id} is not present in the adjacency map.")
 
         for (adjacentVertex in adjacentVertices) adjacencyMap[adjacentVertex]?.remove(vertexToRemove)
 
@@ -61,4 +58,8 @@ abstract class Graph<D, E : Edge<D>> {
             if (edge.isIncident(vertexToRemove)) edges.remove(edge)
         }
     }
+
+    fun getVertices() = adjacencyMap.keys.toList()
+
+    fun getEdges() = edges.toList()
 }

--- a/app/src/main/kotlin/model/abstractGraph/Graph.kt
+++ b/app/src/main/kotlin/model/abstractGraph/Graph.kt
@@ -32,11 +32,9 @@ abstract class Graph<D, E : Edge<D>> {
 
         val copyOfLastAddedVertex = Vertex(vertexToRemove.id, lastAddedVertex.data)
 
-        adjacencyMap[copyOfLastAddedVertex] = adjacencyMap[lastAddedVertex]
-            ?: throw NoSuchElementException("Vertex with id ${lastAddedVertex.id} is not present in the adjacency map.")
+        adjacencyMap[copyOfLastAddedVertex] = getNeighbours(lastAddedVertex)
 
-        val adjacentVertices = adjacencyMap[copyOfLastAddedVertex]
-            ?: throw NoSuchElementException("Vertex with id ${copyOfLastAddedVertex.id} is not present in the adjacency map.")
+        val adjacentVertices = getNeighbours(copyOfLastAddedVertex)
 
         for (adjacentVertex in adjacentVertices) {
             if (adjacencyMap[adjacentVertex]?.remove(lastAddedVertex) == true) {
@@ -49,8 +47,7 @@ abstract class Graph<D, E : Edge<D>> {
     }
 
     private fun removeVertexFromIncidentEdgesAndAdjacentVerticesMapValues(vertexToRemove: Vertex<D>) {
-        val adjacentVertices = adjacencyMap[vertexToRemove]
-            ?: throw NoSuchElementException("Vertex with id ${vertexToRemove.id} is not present in the adjacency map.")
+        val adjacentVertices = getNeighbours(vertexToRemove)
 
         for (adjacentVertex in adjacentVertices) adjacencyMap[adjacentVertex]?.remove(vertexToRemove)
 
@@ -62,4 +59,11 @@ abstract class Graph<D, E : Edge<D>> {
     fun getVertices() = adjacencyMap.keys.toList()
 
     fun getEdges() = edges.toList()
+
+    protected fun getNeighbours(vertex: Vertex<D>): ArrayList<Vertex<D>> {
+        val neighbours = adjacencyMap[vertex]
+            ?: throw NoSuchElementException("Vertex with id ${vertex.id} is not present in the adjacency map.")
+
+        return neighbours
+    }
 }

--- a/app/src/main/kotlin/model/internalGraphs/_DirectedGraph.kt
+++ b/app/src/main/kotlin/model/internalGraphs/_DirectedGraph.kt
@@ -10,7 +10,7 @@ abstract class _DirectedGraph<D, E : DirectedEdge<D>> : Graph<D, E>() {
             throw IllegalArgumentException("Can't add edge from vertex to itself.")
 
         if (vertex1 !in adjacencyMap.keys || vertex2 !in adjacencyMap.keys)
-            throw IllegalArgumentException("Vertex1 or vertex2 is not in the adjacency map.")
+            throw NoSuchElementException("Vertex1 or vertex2 is not in the adjacency map.")
 
         val newEdge = DirectedEdge(vertex1, vertex2) as E
         edges.add(newEdge)
@@ -21,7 +21,7 @@ abstract class _DirectedGraph<D, E : DirectedEdge<D>> : Graph<D, E>() {
 
     override fun removeEdge(edgeToRemove: E): E {
         if (edgeToRemove !in edges)
-            throw IllegalArgumentException("Edge is not in the graph")
+            throw NoSuchElementException("Edge is not in the graph")
 
         val vertex1 = edgeToRemove.vertex1
         val vertex2 = edgeToRemove.vertex2

--- a/app/src/main/kotlin/model/internalGraphs/_DirectedGraph.kt
+++ b/app/src/main/kotlin/model/internalGraphs/_DirectedGraph.kt
@@ -6,9 +6,11 @@ import model.edges.DirectedEdge
 
 abstract class _DirectedGraph<D, E : DirectedEdge<D>> : Graph<D, E>() {
     override fun addEdge(vertex1: Vertex<D>, vertex2: Vertex<D>): E {
-        if (vertex1 == vertex2) throw IllegalArgumentException("Vertices are the same")
+        if (vertex1 == vertex2)
+            throw IllegalArgumentException("Can't add edge from vertex to itself.")
+
         if (vertex1 !in adjacencyMap.keys || vertex2 !in adjacencyMap.keys)
-            throw IllegalArgumentException("Vertex1 or vertex2 are not in the graph")
+            throw IllegalArgumentException("Vertex1 or vertex2 is not in the adjacency map.")
 
         val newEdge = DirectedEdge(vertex1, vertex2) as E
         edges.add(newEdge)
@@ -18,7 +20,8 @@ abstract class _DirectedGraph<D, E : DirectedEdge<D>> : Graph<D, E>() {
     }
 
     override fun removeEdge(edgeToRemove: E): E {
-        if (edgeToRemove !in edges) throw IllegalArgumentException("Edge is not in the graph")
+        if (edgeToRemove !in edges)
+            throw IllegalArgumentException("Edge is not in the graph")
 
         val vertex1 = edgeToRemove.vertex1
         val vertex2 = edgeToRemove.vertex2
@@ -35,19 +38,19 @@ abstract class _DirectedGraph<D, E : DirectedEdge<D>> : Graph<D, E>() {
         val component = arrayListOf<Vertex<D>>()
         val sccList: ArrayList<ArrayList<Vertex<D>>> = arrayListOf()
 
-        fun auxuiliaryDFS(srcVertex: Vertex<D>, componentList: ArrayList<Vertex<D>>) {
+        fun auxiliaryDFS(srcVertex: Vertex<D>, componentList: ArrayList<Vertex<D>>) {
             visited[srcVertex] = true
             componentList.add(srcVertex)
             adjacencyMap[srcVertex]?.forEach { vertex2 ->
                 if (visited[vertex2] != null && visited[vertex2] != true) {
-                    auxuiliaryDFS(vertex2, componentList)
+                    auxiliaryDFS(vertex2, componentList)
                 }
             }
             stack.add(srcVertex)
         }
 
         for (vertex in adjacencyMap.keys) {
-            if (visited[vertex] != null && visited[vertex] != true) auxuiliaryDFS(vertex, component)
+            if (visited[vertex] != null && visited[vertex] != true) auxiliaryDFS(vertex, component)
         }
 
         reverseGraph()
@@ -58,7 +61,7 @@ abstract class _DirectedGraph<D, E : DirectedEdge<D>> : Graph<D, E>() {
             val vertex = stack.removeLast()
             if (visited[vertex] != null && visited[vertex] != true) {
                 val currentComponent = arrayListOf<Vertex<D>>()
-                auxuiliaryDFS(vertex, currentComponent)
+                auxiliaryDFS(vertex, currentComponent)
                 sccList.add(currentComponent)
             }
         }

--- a/app/src/main/kotlin/model/internalGraphs/_UndirectedGraph.kt
+++ b/app/src/main/kotlin/model/internalGraphs/_UndirectedGraph.kt
@@ -6,9 +6,11 @@ import model.edges.UndirectedEdge
 
 abstract class _UndirectedGraph<D, E : UndirectedEdge<D>> : Graph<D, E>() {
     override fun addEdge(vertex1: Vertex<D>, vertex2: Vertex<D>): E {
-        if (vertex1 == vertex2) throw IllegalArgumentException("Vertices are the same")
+        if (vertex1 == vertex2)
+            throw IllegalArgumentException("Can't add edge from vertex to itself.")
+
         if (vertex1 !in adjacencyMap.keys || vertex2 !in adjacencyMap.keys)
-            throw IllegalArgumentException("Vertex1 or vertex2 are not in the graph")
+            throw IllegalArgumentException("Vertex1 or vertex2 is not in the adjacency map.")
 
         val newEdge = UndirectedEdge(vertex1, vertex2) as E
         edges.add(newEdge)
@@ -19,7 +21,8 @@ abstract class _UndirectedGraph<D, E : UndirectedEdge<D>> : Graph<D, E>() {
     }
 
     override fun removeEdge(edgeToRemove: E): E {
-        if (edgeToRemove !in edges) throw IllegalArgumentException("Edge is not in the graph")
+        if (edgeToRemove !in edges)
+            throw IllegalArgumentException("Edge is not in the graph.")
 
         val vertex1 = edgeToRemove.vertex1
         val vertex2 = edgeToRemove.vertex2

--- a/app/src/main/kotlin/model/internalGraphs/_UndirectedGraph.kt
+++ b/app/src/main/kotlin/model/internalGraphs/_UndirectedGraph.kt
@@ -10,7 +10,7 @@ abstract class _UndirectedGraph<D, E : UndirectedEdge<D>> : Graph<D, E>() {
             throw IllegalArgumentException("Can't add edge from vertex to itself.")
 
         if (vertex1 !in adjacencyMap.keys || vertex2 !in adjacencyMap.keys)
-            throw IllegalArgumentException("Vertex1 or vertex2 is not in the adjacency map.")
+            throw NoSuchElementException("Vertex1 or vertex2 is not in the adjacency map.")
 
         val newEdge = UndirectedEdge(vertex1, vertex2) as E
         edges.add(newEdge)
@@ -22,7 +22,7 @@ abstract class _UndirectedGraph<D, E : UndirectedEdge<D>> : Graph<D, E>() {
 
     override fun removeEdge(edgeToRemove: E): E {
         if (edgeToRemove !in edges)
-            throw IllegalArgumentException("Edge is not in the graph.")
+            throw NoSuchElementException("Edge is not in the graph.")
 
         val vertex1 = edgeToRemove.vertex1
         val vertex2 = edgeToRemove.vertex2

--- a/app/src/main/kotlin/model/internalGraphs/_WeightedDirectedGraph.kt
+++ b/app/src/main/kotlin/model/internalGraphs/_WeightedDirectedGraph.kt
@@ -6,9 +6,11 @@ import model.edges.WeightedDirectedEdge
 
 abstract class _WeightedDirectedGraph<D, E : WeightedDirectedEdge<D>> : _DirectedGraph<D, E>() {
     fun addEdge(vertex1: Vertex<D>, vertex2: Vertex<D>, weight: Int): E {
-        if (vertex1 == vertex2) throw IllegalArgumentException("Vertices are the same")
+        if (vertex1 == vertex2)
+            throw IllegalArgumentException("Can't add edge from vertex to itself.")
+
         if (vertex1 !in adjacencyMap.keys || vertex2 !in adjacencyMap.keys)
-            throw IllegalArgumentException("Vertex1 or vertex2 are not in the graph")
+            throw IllegalArgumentException("Vertex1 or vertex2 is not in the adjacency map.")
 
         val newEdge = WeightedDirectedEdge(vertex1, vertex2, weight) as E
         edges.add(newEdge)

--- a/app/src/main/kotlin/model/internalGraphs/_WeightedDirectedGraph.kt
+++ b/app/src/main/kotlin/model/internalGraphs/_WeightedDirectedGraph.kt
@@ -3,6 +3,7 @@ package model.internalGraphs
 import java.util.*
 import model.abstractGraph.Vertex
 import model.edges.WeightedDirectedEdge
+import kotlin.NoSuchElementException
 
 abstract class _WeightedDirectedGraph<D, E : WeightedDirectedEdge<D>> : _DirectedGraph<D, E>() {
     fun addEdge(vertex1: Vertex<D>, vertex2: Vertex<D>, weight: Int): E {
@@ -10,7 +11,7 @@ abstract class _WeightedDirectedGraph<D, E : WeightedDirectedEdge<D>> : _Directe
             throw IllegalArgumentException("Can't add edge from vertex to itself.")
 
         if (vertex1 !in adjacencyMap.keys || vertex2 !in adjacencyMap.keys)
-            throw IllegalArgumentException("Vertex1 or vertex2 is not in the adjacency map.")
+            throw NoSuchElementException("Vertex1 or vertex2 is not in the adjacency map.")
 
         val newEdge = WeightedDirectedEdge(vertex1, vertex2, weight) as E
         edges.add(newEdge)
@@ -60,7 +61,7 @@ abstract class _WeightedDirectedGraph<D, E : WeightedDirectedEdge<D>> : _Directe
                 return emptyList()
             }
             if (edges.find { it.vertex1 == predecessor && it.vertex2 == currentVertex } == null) {
-                throw IllegalArgumentException("Edge is not in the graph, path cannot be reconstructed.")
+                throw NoSuchElementException("Edge is not in the graph, path cannot be reconstructed.")
             }
             path.add(
                 Pair(currentVertex, edges.find { it.vertex1 == predecessor && it.vertex2 == currentVertex })

--- a/app/src/main/kotlin/model/internalGraphs/_WeightedUndirectedGraph.kt
+++ b/app/src/main/kotlin/model/internalGraphs/_WeightedUndirectedGraph.kt
@@ -6,9 +6,11 @@ import model.edges.WeightedUndirectedEdge
 
 abstract class _WeightedUndirectedGraph<D, E : WeightedUndirectedEdge<D>> : _UndirectedGraph<D, E>() {
     fun addEdge(vertex1: Vertex<D>, vertex2: Vertex<D>, weight: Int): E {
-        if (vertex1 == vertex2) throw IllegalArgumentException("Vertices are the same")
+        if (vertex1 == vertex2)
+            throw IllegalArgumentException("Can't add edge from vertex to itself.")
+
         if (vertex1 !in adjacencyMap.keys || vertex2 !in adjacencyMap.keys)
-            throw IllegalArgumentException("Vertex1 or vertex2 are not in the graph")
+            throw IllegalArgumentException("Vertex1 or vertex2 is not in the adjacency map.")
 
         val newEdge = WeightedUndirectedEdge(vertex1, vertex2, weight) as E
         edges.add(newEdge)

--- a/app/src/main/kotlin/model/internalGraphs/_WeightedUndirectedGraph.kt
+++ b/app/src/main/kotlin/model/internalGraphs/_WeightedUndirectedGraph.kt
@@ -3,6 +3,7 @@ package model.internalGraphs
 import java.util.*
 import model.abstractGraph.Vertex
 import model.edges.WeightedUndirectedEdge
+import kotlin.NoSuchElementException
 
 abstract class _WeightedUndirectedGraph<D, E : WeightedUndirectedEdge<D>> : _UndirectedGraph<D, E>() {
     fun addEdge(vertex1: Vertex<D>, vertex2: Vertex<D>, weight: Int): E {
@@ -10,7 +11,7 @@ abstract class _WeightedUndirectedGraph<D, E : WeightedUndirectedEdge<D>> : _Und
             throw IllegalArgumentException("Can't add edge from vertex to itself.")
 
         if (vertex1 !in adjacencyMap.keys || vertex2 !in adjacencyMap.keys)
-            throw IllegalArgumentException("Vertex1 or vertex2 is not in the adjacency map.")
+            throw NoSuchElementException("Vertex1 or vertex2 is not in the adjacency map.")
 
         val newEdge = WeightedUndirectedEdge(vertex1, vertex2, weight) as E
         edges.add(newEdge)
@@ -68,7 +69,7 @@ abstract class _WeightedUndirectedGraph<D, E : WeightedUndirectedEdge<D>> : _Und
                 it.vertex1 == predecessor && it.vertex2 == currentVertex ||
                     it.vertex2 == predecessor && it.vertex1 == currentVertex
             } == null) {
-                throw IllegalArgumentException("Edge is not in the graph, path cannot be reconstructed.")
+                throw NoSuchElementException("Edge is not in the graph, path cannot be reconstructed.")
             }
             path.add(
                 Pair(


### PR DESCRIPTION
Replace some `IllegalArgumentExceptions` with `NoSuchElementExceptions`. 

Add `getNeighbours()` function to localize exceptions when working with adjacency map.

Do refactor of exceptions and their messages code styles, and a small refactor in other places.