### PR TITLE
Add test classes and inner test classes for methods, parameterized test annotation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
     implementation(libs.koin.core)
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.1")
+    testImplementation("org.junit.jupiter:junit-jupiter-params:5.8.1")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.8.1")
 }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,10 +6,17 @@ plugins {
 dependencies {
     implementation(compose.desktop.currentOs)
     implementation(libs.koin.core)
+
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.1")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.8.1")
 }
 
 compose.desktop {
     application {
         mainClass = "MainKt"
     }
+}
+
+tasks.test {
+    useJUnitPlatform()
 }

--- a/app/src/test/kotlin/model/DirectedGraphTest.kt
+++ b/app/src/test/kotlin/model/DirectedGraphTest.kt
@@ -1,0 +1,14 @@
+package model
+
+import org.junit.jupiter.api.Nested
+
+class DirectedGraphTest {
+    @Nested
+    inner class AddEdgeTest {}
+
+    @Nested
+    inner class RemoveEdgeTest {}
+
+    @Nested
+    inner class FindSCCTest {}
+}

--- a/app/src/test/kotlin/model/UndirectedGraphTest.kt
+++ b/app/src/test/kotlin/model/UndirectedGraphTest.kt
@@ -1,0 +1,14 @@
+package model
+
+import org.junit.jupiter.api.Nested
+
+class UndirectedGraphTest {
+    @Nested
+    inner class AddEdgeTest {}
+
+    @Nested
+    inner class RemoveEdgeTest {}
+
+    @Nested
+    inner class FindBridges {}
+}

--- a/app/src/test/kotlin/model/UndirectedGraphTest.kt
+++ b/app/src/test/kotlin/model/UndirectedGraphTest.kt
@@ -10,5 +10,5 @@ class UndirectedGraphTest {
     inner class RemoveEdgeTest {}
 
     @Nested
-    inner class FindBridges {}
+    inner class FindBridgesTest {}
 }

--- a/app/src/test/kotlin/model/WeightedDirectedGraphTest.kt
+++ b/app/src/test/kotlin/model/WeightedDirectedGraphTest.kt
@@ -1,0 +1,14 @@
+package model
+
+import org.junit.jupiter.api.Nested
+
+class WeightedDirectedGraphTest {
+    @Nested
+    inner class AddEdgeTest {}
+
+    @Nested
+    inner class RemoveEdgeTest {}
+
+    @Nested
+    inner class FindShortestPathDijkstraTest {}
+}

--- a/app/src/test/kotlin/model/WeightedUndirectedGraphTest.kt
+++ b/app/src/test/kotlin/model/WeightedUndirectedGraphTest.kt
@@ -1,0 +1,17 @@
+package model
+
+import org.junit.jupiter.api.Nested
+
+class WeightedUndirectedGraphTest {
+    @Nested
+    inner class AddEdgeTest {}
+
+    @Nested
+    inner class RemoveEdgeTest {}
+
+    @Nested
+    inner class FindShortestPathDijkstraTest {}
+
+    @Nested
+    inner class FindMinSpanningTreeTest {}
+}

--- a/app/src/test/kotlin/model/abstractGraph/GraphTest.kt
+++ b/app/src/test/kotlin/model/abstractGraph/GraphTest.kt
@@ -1,0 +1,18 @@
+package model.abstractGraph
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Nested
+
+class GraphTest {
+    @Nested
+    inner class GetVerticesTest {}
+
+    @Nested
+    inner class GetEdgesTest {}
+
+    @Nested
+    inner class AddVertexTest {}
+
+    @Nested
+    inner class RemoveVertexTest {}
+}

--- a/app/src/test/kotlin/model/abstractGraph/GraphTest.kt
+++ b/app/src/test/kotlin/model/abstractGraph/GraphTest.kt
@@ -1,7 +1,31 @@
 package model.abstractGraph
 
+import model.DirectedGraph
+import model.UndirectedGraph
+import model.WeightedDirectedGraph
+import model.WeightedUndirectedGraph
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
+
+@ParameterizedTest
+@MethodSource("provideAllGraphTypes")
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+private annotation class TestAllGraphTypes
+
+fun provideAllGraphTypes(): Stream<Arguments> {
+    return Stream.of(
+        Arguments.of(UndirectedGraph<Int>()),
+        Arguments.of(DirectedGraph<Int>()),
+        Arguments.of(WeightedDirectedGraph<Int>()),
+        Arguments.of(WeightedUndirectedGraph<Int>())
+    )
+}
 
 class GraphTest {
     @Nested


### PR DESCRIPTION
Add Junit5 dependency to gradle.

Add test classes for all graph types, package structure, inner test classes for methods of graphs.

Add custom annotation for parameterized tests in abstract graph test class.