### PR TITLE
Implement initial UI, add basic structure and logic

### DIFF
--- a/app/src/main/kotlin/Main.kt
+++ b/app/src/main/kotlin/Main.kt
@@ -6,26 +6,26 @@ import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.application
 import androidx.compose.ui.window.rememberWindowState
+import java.awt.Dimension
 import model.UndirectedGraph
 import model.abstractGraph.Graph
 import view.MainScreen
 import viewmodel.MainScreenViewModel
-import java.awt.Dimension
 
-val testGraph: Graph<Int> = UndirectedGraph<Int>().apply {
-    val v1 = addVertex(1)
-    val v2 = addVertex(2)
-    val v3 = addVertex(3)
-    val v4 = addVertex(4)
-    val v5 = addVertex(5)
+val testGraph: Graph<Int> =
+    UndirectedGraph<Int>().apply {
+        val v1 = addVertex(1)
+        val v2 = addVertex(2)
+        val v3 = addVertex(3)
+        val v4 = addVertex(4)
+        val v5 = addVertex(5)
 
-    addEdge(v1, v5)
-    addEdge(v1, v4)
-    addEdge(v1, v3)
-    addEdge(v1, v2)
-    addEdge(v2, v4)
-}
-
+        addEdge(v1, v5)
+        addEdge(v1, v4)
+        addEdge(v1, v3)
+        addEdge(v1, v2)
+        addEdge(v2, v4)
+    }
 
 @Composable
 @Preview
@@ -37,9 +37,11 @@ fun main() = application {
     Window(
         onCloseRequest = ::exitApplication,
         title = "Graphs-2",
-        state = rememberWindowState(
-            position = WindowPosition(alignment = Alignment.Center),
-        ),) {
+        state =
+            rememberWindowState(
+                position = WindowPosition(alignment = Alignment.Center),
+            ),
+    ) {
         window.minimumSize = Dimension(1200, 700)
         App()
     }

--- a/app/src/main/kotlin/Main.kt
+++ b/app/src/main/kotlin/Main.kt
@@ -9,13 +9,35 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
+import model.DirectedGraph
+import model.UndirectedGraph
+import model.abstractGraph.Graph
+import view.MainScreen
+import viewmodel.MainScreenViewModel
+
+val testGraph: Graph<Int> = UndirectedGraph<Int>().apply {
+    val v1 = addVertex(1)
+    val v2 = addVertex(2)
+    val v3 = addVertex(3)
+    val v4 = addVertex(4)
+    val v5 = addVertex(5)
+
+    addEdge(v1, v5)
+    addEdge(v1, v4)
+    addEdge(v1, v3)
+    addEdge(v1, v2)
+    addEdge(v2, v4)
+}
+
 
 @Composable
 @Preview
 fun App() {
-    var text by remember { mutableStateOf("Hello, World!") }
-
-    MaterialTheme { Button(onClick = { text = "Hello, Desktop!" }) { Text(text) } }
+    MaterialTheme { MainScreen(MainScreenViewModel(testGraph)) }
 }
 
-fun main() = application { Window(onCloseRequest = ::exitApplication) { App() } }
+fun main() = application {
+    Window(onCloseRequest = ::exitApplication) {
+        App()
+    }
+}

--- a/app/src/main/kotlin/Main.kt
+++ b/app/src/main/kotlin/Main.kt
@@ -1,19 +1,16 @@
 import androidx.compose.desktop.ui.tooling.preview.Preview
-import androidx.compose.material.Button
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.application
-import model.DirectedGraph
+import androidx.compose.ui.window.rememberWindowState
 import model.UndirectedGraph
 import model.abstractGraph.Graph
 import view.MainScreen
 import viewmodel.MainScreenViewModel
+import java.awt.Dimension
 
 val testGraph: Graph<Int> = UndirectedGraph<Int>().apply {
     val v1 = addVertex(1)
@@ -37,7 +34,13 @@ fun App() {
 }
 
 fun main() = application {
-    Window(onCloseRequest = ::exitApplication) {
+    Window(
+        onCloseRequest = ::exitApplication,
+        title = "Graphs-2",
+        state = rememberWindowState(
+            position = WindowPosition(alignment = Alignment.Center),
+        ),) {
+        window.minimumSize = Dimension(1200, 700)
         App()
     }
 }

--- a/app/src/main/kotlin/view/MainScreen.kt
+++ b/app/src/main/kotlin/view/MainScreen.kt
@@ -7,13 +7,21 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.*
 import androidx.compose.material.TabRowDefaults.tabIndicatorOffset
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import viewmodel.MainScreenViewModel
@@ -26,12 +34,15 @@ fun <D> MainScreen(viewmodel: MainScreenViewModel<D>) {
     // here we will have layout type shit
     Row(horizontalArrangement = Arrangement.spacedBy(30.dp)) {
         Column(
-            modifier = Modifier.width(390.dp).background(color = Color.LightGray).fillMaxHeight()
+            modifier = Modifier.width(360.dp)
+                .background(color = Color.LightGray, shape = RoundedCornerShape(20.dp))
+                .fillMaxHeight().clip(shape = RoundedCornerShape(20.dp))
+                // TODO: make it rounded only from right side
         ) {
 
             val pageState = rememberPagerState( pageCount = { 3 } )
             val coroutineScope = rememberCoroutineScope()
-            val tabs = listOf("General", "Analyze", "File Control")
+            val tabs = listOf("General", "Analyze", " File Control")
 
             TabRow(
                 selectedTabIndex = pageState.currentPage,
@@ -51,15 +62,19 @@ fun <D> MainScreen(viewmodel: MainScreenViewModel<D>) {
                         selected = pageState.currentPage == index,
                         onClick = { coroutineScope.launch { pageState.animateScrollToPage(index) } },
                         modifier = Modifier.padding(0.dp),
+
                         content = {
                             Box(
-                                modifier = Modifier.background(
+                                modifier = Modifier
+                                    .background(
                                         if (pageState.currentPage == index) Color.Magenta
                                         else Color.Transparent
-                                    ).padding(10.dp).height(30.dp).width(110.dp).align(Alignment.CenterHorizontally)
+                                    ).padding(10.dp).height(30.dp).width(120.dp).align(Alignment.CenterHorizontally),
+                                contentAlignment = Alignment.Center
                             ) {
                                 Text(
                                     text = title,
+                                    textAlign = TextAlign.Center,
                                     color = if (pageState.currentPage == index) Color.White else Color.Black // Set text color for selected and unselected tabs
                                 )
                             }

--- a/app/src/main/kotlin/view/MainScreen.kt
+++ b/app/src/main/kotlin/view/MainScreen.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalFoundationApi::class)
-
 package view
 
 import androidx.compose.foundation.ExperimentalFoundationApi
@@ -14,16 +12,11 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Outline
-import androidx.compose.ui.graphics.Path
-import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.Density
-import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
+import view.graph.GraphView
 import viewmodel.MainScreenViewModel
 
 
@@ -31,12 +24,11 @@ import viewmodel.MainScreenViewModel
 @Composable
 fun <D> MainScreen(viewmodel: MainScreenViewModel<D>) {
 
-    // here we will have layout type shit
-    Row(horizontalArrangement = Arrangement.spacedBy(30.dp)) {
+    Row {
         Column(
             modifier = Modifier.width(360.dp)
-                .background(color = Color.LightGray, shape = RoundedCornerShape(20.dp))
-                .fillMaxHeight().clip(shape = RoundedCornerShape(20.dp))
+                .background(color = Color.White)
+                .fillMaxHeight().clip(shape = RoundedCornerShape(10.dp))
                 // TODO: make it rounded only from right side
         ) {
 
@@ -50,8 +42,8 @@ fun <D> MainScreen(viewmodel: MainScreenViewModel<D>) {
                 backgroundColor = Color.Gray,
                 divider = {}, // to remove divider between
                 indicator = { tabPositions ->
-                    TabRowDefaults.Indicator(
-                        modifier = Modifier.tabIndicatorOffset(tabPositions[pageState.currentPage]),
+                    TabRowDefaults.Indicator(modifier = Modifier
+                        .tabIndicatorOffset(tabPositions[pageState.currentPage]),
                         height = 0.dp
                     )
                 },
@@ -61,11 +53,10 @@ fun <D> MainScreen(viewmodel: MainScreenViewModel<D>) {
                     Tab(
                         selected = pageState.currentPage == index,
                         onClick = { coroutineScope.launch { pageState.animateScrollToPage(index) } },
-                        modifier = Modifier.padding(0.dp),
+                        modifier = Modifier,
 
                         content = {
-                            Box(
-                                modifier = Modifier
+                            Box(modifier = Modifier
                                     .background(
                                         if (pageState.currentPage == index) Color.Magenta
                                         else Color.Transparent
@@ -75,27 +66,27 @@ fun <D> MainScreen(viewmodel: MainScreenViewModel<D>) {
                                 Text(
                                     text = title,
                                     textAlign = TextAlign.Center,
-                                    color = if (pageState.currentPage == index) Color.White else Color.Black // Set text color for selected and unselected tabs
+                                    color = if (pageState.currentPage == index) Color.White else Color.Black
+                                    // Set text color for selected and unselected tabs
                                 )
                             }
                         }
                     )
                 }
             }
-            HorizontalPager(state = pageState, userScrollEnabled = false) {
+            HorizontalPager(state = pageState, userScrollEnabled = true) {
                 page ->
                 Column(
-                    modifier = Modifier.width(100.dp),
+                    modifier = Modifier.width(360.dp).background(Color.LightGray).fillMaxHeight(),
                     horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.Center,
+                    verticalArrangement = Arrangement.Top,
                 ) {
                     Text(text = "Hello from page: $page")
                 }
             }
         }
-    }
-
-    Surface {
-//        GraphView(viewmodel.graphViewModel)
+        Surface(modifier = Modifier.fillMaxSize(), color = Color.Transparent) {
+            GraphView(viewmodel.graphViewModel)
+        }
     }
 }

--- a/app/src/main/kotlin/view/MainScreen.kt
+++ b/app/src/main/kotlin/view/MainScreen.kt
@@ -2,6 +2,7 @@ package view
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
@@ -12,11 +13,12 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.unit.dp
-import kotlinx.coroutines.launch
 import view.graph.GraphView
+import view.tabScreen.*
 import viewmodel.MainScreenViewModel
 
 
@@ -50,42 +52,28 @@ fun <D> MainScreen(viewmodel: MainScreenViewModel<D>) {
                 modifier = Modifier.height(50.dp)
             ) {
                 tabs.forEachIndexed { index, title ->
-                    Tab(
-                        selected = pageState.currentPage == index,
-                        onClick = { coroutineScope.launch { pageState.animateScrollToPage(index) } },
-                        modifier = Modifier,
-
-                        content = {
-                            Box(modifier = Modifier
-                                    .background(
-                                        if (pageState.currentPage == index) Color.Magenta
-                                        else Color.Transparent
-                                    ).padding(10.dp).height(30.dp).width(120.dp).align(Alignment.CenterHorizontally),
-                                contentAlignment = Alignment.Center
-                            ) {
-                                Text(
-                                    text = title,
-                                    textAlign = TextAlign.Center,
-                                    color = if (pageState.currentPage == index) Color.White else Color.Black
-                                    // Set text color for selected and unselected tabs
-                                )
-                            }
-                        }
-                    )
+                    SelectTabRow(pageState, index, coroutineScope, title)
                 }
             }
+
             HorizontalPager(state = pageState, userScrollEnabled = true) {
-                page ->
                 Column(
                     modifier = Modifier.width(360.dp).background(Color.LightGray).fillMaxHeight(),
                     horizontalAlignment = Alignment.CenterHorizontally,
                     verticalArrangement = Arrangement.Top,
                 ) {
-                    Text(text = "Hello from page: $page")
+                    when (pageState.currentPage) {
+                        0 -> GeneralTab()
+                        1 -> AnalyzeTab()
+                        2 -> FileControlTab()
+                    }
                 }
             }
         }
-        Surface(modifier = Modifier.fillMaxSize(), color = Color.Transparent) {
+
+        Surface(modifier = Modifier
+            .fillMaxSize().border(2f.dp, Color.LightGray, RectangleShape)
+            .clipToBounds(), color = Color.Transparent) {
             GraphView(viewmodel.graphViewModel)
         }
     }

--- a/app/src/main/kotlin/view/MainScreen.kt
+++ b/app/src/main/kotlin/view/MainScreen.kt
@@ -21,20 +21,20 @@ import view.graph.GraphView
 import view.tabScreen.*
 import viewmodel.MainScreenViewModel
 
-
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun <D> MainScreen(viewmodel: MainScreenViewModel<D>) {
 
     Row {
         Column(
-            modifier = Modifier.width(360.dp)
-                .background(color = Color.White)
-                .fillMaxHeight().clip(shape = RoundedCornerShape(10.dp))
-                // TODO: make it rounded only from right side
+            modifier =
+                Modifier.width(360.dp)
+                    .background(color = Color.White)
+                    .fillMaxHeight()
+                    .clip(shape = RoundedCornerShape(10.dp))
+            // TODO: make it rounded only from right side
         ) {
-
-            val pageState = rememberPagerState( pageCount = { 3 } )
+            val pageState = rememberPagerState(pageCount = { 3 })
             val coroutineScope = rememberCoroutineScope()
             val tabs = listOf("General", "Analyze", " File Control")
 
@@ -44,8 +44,8 @@ fun <D> MainScreen(viewmodel: MainScreenViewModel<D>) {
                 backgroundColor = Color.Gray,
                 divider = {}, // to remove divider between
                 indicator = { tabPositions ->
-                    TabRowDefaults.Indicator(modifier = Modifier
-                        .tabIndicatorOffset(tabPositions[pageState.currentPage]),
+                    TabRowDefaults.Indicator(
+                        modifier = Modifier.tabIndicatorOffset(tabPositions[pageState.currentPage]),
                         height = 0.dp
                     )
                 },
@@ -71,9 +71,13 @@ fun <D> MainScreen(viewmodel: MainScreenViewModel<D>) {
             }
         }
 
-        Surface(modifier = Modifier
-            .fillMaxSize().border(2f.dp, Color.LightGray, RectangleShape)
-            .clipToBounds(), color = Color.Transparent) {
+        Surface(
+            modifier =
+                Modifier.fillMaxSize()
+                    .border(2f.dp, Color.LightGray, RectangleShape)
+                    .clipToBounds(),
+            color = Color.Transparent
+        ) {
             GraphView(viewmodel.graphViewModel)
         }
     }

--- a/app/src/main/kotlin/view/MainScreen.kt
+++ b/app/src/main/kotlin/view/MainScreen.kt
@@ -1,0 +1,86 @@
+@file:OptIn(ExperimentalFoundationApi::class)
+
+package view
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material.*
+import androidx.compose.material.TabRowDefaults.tabIndicatorOffset
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
+import viewmodel.MainScreenViewModel
+
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun <D> MainScreen(viewmodel: MainScreenViewModel<D>) {
+
+    // here we will have layout type shit
+    Row(horizontalArrangement = Arrangement.spacedBy(30.dp)) {
+        Column(
+            modifier = Modifier.width(390.dp).background(color = Color.LightGray).fillMaxHeight()
+        ) {
+
+            val pageState = rememberPagerState( pageCount = { 3 } )
+            val coroutineScope = rememberCoroutineScope()
+            val tabs = listOf("General", "Analyze", "File Control")
+
+            TabRow(
+                selectedTabIndex = pageState.currentPage,
+                contentColor = Color.Red,
+                backgroundColor = Color.Gray,
+                divider = {}, // to remove divider between
+                indicator = { tabPositions ->
+                    TabRowDefaults.Indicator(
+                        modifier = Modifier.tabIndicatorOffset(tabPositions[pageState.currentPage]),
+                        height = 0.dp
+                    )
+                },
+                modifier = Modifier.height(50.dp)
+            ) {
+                tabs.forEachIndexed { index, title ->
+                    Tab(
+                        selected = pageState.currentPage == index,
+                        onClick = { coroutineScope.launch { pageState.animateScrollToPage(index) } },
+                        modifier = Modifier.padding(0.dp),
+                        content = {
+                            Box(
+                                modifier = Modifier.background(
+                                        if (pageState.currentPage == index) Color.Magenta
+                                        else Color.Transparent
+                                    ).padding(10.dp).height(30.dp).width(110.dp).align(Alignment.CenterHorizontally)
+                            ) {
+                                Text(
+                                    text = title,
+                                    color = if (pageState.currentPage == index) Color.White else Color.Black // Set text color for selected and unselected tabs
+                                )
+                            }
+                        }
+                    )
+                }
+            }
+            HorizontalPager(state = pageState, userScrollEnabled = false) {
+                page ->
+                Column(
+                    modifier = Modifier.width(100.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center,
+                ) {
+                    Text(text = "Hello from page: $page")
+                }
+            }
+        }
+    }
+
+    Surface {
+//        GraphView(viewmodel.graphViewModel)
+    }
+}

--- a/app/src/main/kotlin/view/graph/EdgeView.kt
+++ b/app/src/main/kotlin/view/graph/EdgeView.kt
@@ -1,9 +1,7 @@
 package view.graph
 
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -12,21 +10,21 @@ import androidx.compose.ui.unit.dp
 import viewmodel.graph.EdgeViewModel
 
 @Composable
-fun <D> EdgeView(
-    viewModel: EdgeViewModel<D>
-) {
+fun <D> EdgeView(viewModel: EdgeViewModel<D>) {
     Canvas(modifier = Modifier.size(300.dp, 300.dp)) {
         drawLine(
             color = Color.Red,
             strokeWidth = 10.0f,
-            start = Offset(
-                viewModel.firstVertex.x.value.toPx() + viewModel.firstVertex.radius.toPx(),
-                viewModel.firstVertex.y.value.toPx() + viewModel.firstVertex.radius.toPx()
-            ),
-            end = Offset(
-                viewModel.secondVertex.x.value.toPx() + viewModel.secondVertex.radius.toPx(),
-                viewModel.secondVertex.y.value.toPx() + viewModel.secondVertex.radius.toPx()
-            ),
+            start =
+                Offset(
+                    viewModel.firstVertex.x.value.toPx() + viewModel.firstVertex.radius.toPx(),
+                    viewModel.firstVertex.y.value.toPx() + viewModel.firstVertex.radius.toPx()
+                ),
+            end =
+                Offset(
+                    viewModel.secondVertex.x.value.toPx() + viewModel.secondVertex.radius.toPx(),
+                    viewModel.secondVertex.y.value.toPx() + viewModel.secondVertex.radius.toPx()
+                ),
             alpha = 1.0f
         )
     }

--- a/app/src/main/kotlin/view/graph/EdgeView.kt
+++ b/app/src/main/kotlin/view/graph/EdgeView.kt
@@ -1,0 +1,33 @@
+package view.graph
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import viewmodel.graph.EdgeViewModel
+
+@Composable
+fun <D> EdgeView(
+    viewModel: EdgeViewModel<D>
+) {
+    Canvas(modifier = Modifier.size(300.dp, 300.dp)) {
+        drawLine(
+            color = Color.Red,
+            strokeWidth = 10.0f,
+            start = Offset(
+                viewModel.firstVertex.x.toPx() + viewModel.firstVertex.radius.toPx(),
+                viewModel.firstVertex.y.toPx() + viewModel.firstVertex.radius.toPx()
+            ),
+            end = Offset(
+                viewModel.secondVertex.x.toPx() + viewModel.secondVertex.radius.toPx(),
+                viewModel.secondVertex.y.toPx() + viewModel.secondVertex.radius.toPx()
+            ),
+            alpha = 1.0f
+        )
+    }
+}

--- a/app/src/main/kotlin/view/graph/EdgeView.kt
+++ b/app/src/main/kotlin/view/graph/EdgeView.kt
@@ -20,12 +20,12 @@ fun <D> EdgeView(
             color = Color.Red,
             strokeWidth = 10.0f,
             start = Offset(
-                viewModel.firstVertex.x.toPx() + viewModel.firstVertex.radius.toPx(),
-                viewModel.firstVertex.y.toPx() + viewModel.firstVertex.radius.toPx()
+                viewModel.firstVertex.x.value.toPx() + viewModel.firstVertex.radius.toPx(),
+                viewModel.firstVertex.y.value.toPx() + viewModel.firstVertex.radius.toPx()
             ),
             end = Offset(
-                viewModel.secondVertex.x.toPx() + viewModel.secondVertex.radius.toPx(),
-                viewModel.secondVertex.y.toPx() + viewModel.secondVertex.radius.toPx()
+                viewModel.secondVertex.x.value.toPx() + viewModel.secondVertex.radius.toPx(),
+                viewModel.secondVertex.y.value.toPx() + viewModel.secondVertex.radius.toPx()
             ),
             alpha = 1.0f
         )

--- a/app/src/main/kotlin/view/graph/GraphView.kt
+++ b/app/src/main/kotlin/view/graph/GraphView.kt
@@ -1,0 +1,25 @@
+package view.graph
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import model.abstractGraph.Edge
+import viewmodel.graph.GraphViewModel
+
+@Composable
+fun <D>GraphView(viewModel: GraphViewModel<D>) {
+    Box(modifier = Modifier.fillMaxSize().background(Color.White)) {
+        viewModel.verticesVM.forEach { v ->
+            VertexView(v)
+        }
+        viewModel.edgesVM.forEach { e ->
+            EdgeView(e)
+        }
+    }
+}

--- a/app/src/main/kotlin/view/graph/GraphView.kt
+++ b/app/src/main/kotlin/view/graph/GraphView.kt
@@ -3,23 +3,15 @@ package view.graph
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.dp
-import model.abstractGraph.Edge
 import viewmodel.graph.GraphViewModel
 
 @Composable
-fun <D>GraphView(viewModel: GraphViewModel<D>) {
+fun <D> GraphView(viewModel: GraphViewModel<D>) {
     Box(modifier = Modifier.fillMaxSize().background(Color.White)) {
-        viewModel.verticesVM.forEach { v ->
-            VertexView(v)
-        }
-        viewModel.edgesVM.forEach { e ->
-            EdgeView(e)
-        }
+        viewModel.verticesVM.forEach { v -> VertexView(v) }
+        viewModel.edgesVM.forEach { e -> EdgeView(e) }
     }
 }

--- a/app/src/main/kotlin/view/graph/VertexView.kt
+++ b/app/src/main/kotlin/view/graph/VertexView.kt
@@ -1,0 +1,58 @@
+package view.graph
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.consumeAllChanges
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import viewmodel.graph.VertexViewModel
+
+
+@Composable
+fun <D> VertexView(viewModel: VertexViewModel<D>) {
+    val coroutineScope = rememberCoroutineScope()
+
+    Box(modifier = Modifier
+        .offset { IntOffset(viewModel.x.roundToPx(), viewModel.y.roundToPx()) }
+        .size(viewModel.radius * 2, viewModel.radius * 2)
+        .background(if (viewModel.isSelected) Color.Yellow else Color.LightGray, shape = CircleShape)
+        .clip(CircleShape)
+        .pointerInput(Unit) {
+            coroutineScope.launch {
+                detectDragGestures { change, dragAmount ->
+                    viewModel.onDrag(DpOffset(dragAmount.x.toDp(), dragAmount.y.toDp()))
+                    change.consume()
+                }
+                detectTapGestures (
+                    onTap = {viewModel.isSelected = !viewModel.isSelected }
+                )
+            }
+        },
+        contentAlignment = Alignment.Center
+    ) {
+        if (viewModel.dataVisible.value) {
+            Text(modifier = Modifier
+                .align(Alignment.Center),
+                text = viewModel.getVertexData)
+        }
+    }
+}

--- a/app/src/main/kotlin/view/graph/VertexView.kt
+++ b/app/src/main/kotlin/view/graph/VertexView.kt
@@ -9,50 +9,47 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.input.pointer.consumeAllChanges
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.IntOffset
-import androidx.compose.ui.unit.dp
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import viewmodel.graph.VertexViewModel
-
 
 @Composable
 fun <D> VertexView(viewModel: VertexViewModel<D>) {
     val coroutineScope = rememberCoroutineScope()
 
-    Box(modifier = Modifier
-        .offset { IntOffset(viewModel.x.value.roundToPx(), viewModel.y.value.roundToPx()) }
-        .size(viewModel.radius * 2)
-        .background(if (viewModel.isSelected.value) Color.Yellow else Color.LightGray, shape = CircleShape)
-        .clip(CircleShape)
-        .pointerInput(Unit) {
-            coroutineScope.launch {
-                detectDragGestures { change, dragAmount ->
-                    viewModel.onDrag(DpOffset(dragAmount.x.toDp(), dragAmount.y.toDp()))
-                    change.consume()
+    Box(
+        modifier =
+            Modifier.offset {
+                    IntOffset(viewModel.x.value.roundToPx(), viewModel.y.value.roundToPx())
                 }
-                detectTapGestures (
-                    onTap = {viewModel.isSelected.value = !viewModel.isSelected.value }
+                .size(viewModel.radius * 2)
+                .background(
+                    if (viewModel.isSelected.value) Color.Yellow else Color.LightGray,
+                    shape = CircleShape
                 )
-            }
-        },
+                .clip(CircleShape)
+                .pointerInput(Unit) {
+                    coroutineScope.launch {
+                        detectDragGestures { change, dragAmount ->
+                            viewModel.onDrag(DpOffset(dragAmount.x.toDp(), dragAmount.y.toDp()))
+                            change.consume()
+                        }
+                        detectTapGestures(
+                            onTap = { viewModel.isSelected.value = !viewModel.isSelected.value }
+                        )
+                    }
+                },
         contentAlignment = Alignment.Center
     ) {
         if (viewModel.dataVisible.value) {
-            Text(modifier = Modifier
-                .align(Alignment.Center),
-                text = viewModel.getVertexData)
+            Text(modifier = Modifier.align(Alignment.Center), text = viewModel.getVertexData)
         }
     }
 }

--- a/app/src/main/kotlin/view/graph/VertexView.kt
+++ b/app/src/main/kotlin/view/graph/VertexView.kt
@@ -32,9 +32,9 @@ fun <D> VertexView(viewModel: VertexViewModel<D>) {
     val coroutineScope = rememberCoroutineScope()
 
     Box(modifier = Modifier
-        .offset { IntOffset(viewModel.x.roundToPx(), viewModel.y.roundToPx()) }
-        .size(viewModel.radius * 2, viewModel.radius * 2)
-        .background(if (viewModel.isSelected) Color.Yellow else Color.LightGray, shape = CircleShape)
+        .offset { IntOffset(viewModel.x.value.roundToPx(), viewModel.y.value.roundToPx()) }
+        .size(viewModel.radius * 2)
+        .background(if (viewModel.isSelected.value) Color.Yellow else Color.LightGray, shape = CircleShape)
         .clip(CircleShape)
         .pointerInput(Unit) {
             coroutineScope.launch {
@@ -43,7 +43,7 @@ fun <D> VertexView(viewModel: VertexViewModel<D>) {
                     change.consume()
                 }
                 detectTapGestures (
-                    onTap = {viewModel.isSelected = !viewModel.isSelected }
+                    onTap = {viewModel.isSelected.value = !viewModel.isSelected.value }
                 )
             }
         },

--- a/app/src/main/kotlin/view/tabScreen/AnalyzeTab.kt
+++ b/app/src/main/kotlin/view/tabScreen/AnalyzeTab.kt
@@ -8,7 +8,5 @@ import androidx.compose.ui.Modifier
 
 @Composable
 fun AnalyzeTab() {
-    Column(modifier = Modifier.fillMaxSize()) {
-        Text("hahahhahh 2nd tab")
-    }
+    Column(modifier = Modifier.fillMaxSize()) { Text("hahahhahh 2nd tab") }
 }

--- a/app/src/main/kotlin/view/tabScreen/AnalyzeTab.kt
+++ b/app/src/main/kotlin/view/tabScreen/AnalyzeTab.kt
@@ -1,0 +1,14 @@
+package view.tabScreen
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+fun AnalyzeTab() {
+    Column(modifier = Modifier.fillMaxSize()) {
+        Text("hahahhahh 2nd tab")
+    }
+}

--- a/app/src/main/kotlin/view/tabScreen/FileControlTab.kt
+++ b/app/src/main/kotlin/view/tabScreen/FileControlTab.kt
@@ -1,0 +1,14 @@
+package view.tabScreen
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+fun FileControlTab() {
+    Column(modifier = Modifier.fillMaxSize()) {
+        Text("hahahhahh 3rd tab")
+    }
+}

--- a/app/src/main/kotlin/view/tabScreen/FileControlTab.kt
+++ b/app/src/main/kotlin/view/tabScreen/FileControlTab.kt
@@ -8,7 +8,5 @@ import androidx.compose.ui.Modifier
 
 @Composable
 fun FileControlTab() {
-    Column(modifier = Modifier.fillMaxSize()) {
-        Text("hahahhahh 3rd tab")
-    }
+    Column(modifier = Modifier.fillMaxSize()) { Text("hahahhahh 3rd tab") }
 }

--- a/app/src/main/kotlin/view/tabScreen/GeneralTab.kt
+++ b/app/src/main/kotlin/view/tabScreen/GeneralTab.kt
@@ -1,0 +1,14 @@
+package view.tabScreen
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+fun GeneralTab() {
+    Column(modifier = Modifier.fillMaxSize()) {
+        Text("hahahhahh 1st tab")
+    }
+}

--- a/app/src/main/kotlin/view/tabScreen/GeneralTab.kt
+++ b/app/src/main/kotlin/view/tabScreen/GeneralTab.kt
@@ -8,7 +8,5 @@ import androidx.compose.ui.Modifier
 
 @Composable
 fun GeneralTab() {
-    Column(modifier = Modifier.fillMaxSize()) {
-        Text("hahahhahh 1st tab")
-    }
+    Column(modifier = Modifier.fillMaxSize()) { Text("hahahhahh 1st tab") }
 }

--- a/app/src/main/kotlin/view/tabScreen/SelectTabRow.kt
+++ b/app/src/main/kotlin/view/tabScreen/SelectTabRow.kt
@@ -20,18 +20,27 @@ import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
-fun SelectTabRow(currentPageState: PagerState, index: Int, coroutineScope: CoroutineScope, title: String) {
+fun SelectTabRow(
+    currentPageState: PagerState,
+    index: Int,
+    coroutineScope: CoroutineScope,
+    title: String
+) {
     Tab(
         selected = currentPageState.currentPage == index,
         onClick = { coroutineScope.launch { currentPageState.animateScrollToPage(index) } },
         modifier = Modifier,
-
         content = {
-            Box(modifier = Modifier
-                .background(
-                    if (currentPageState.currentPage == index) Color.Magenta
-                    else Color.Transparent
-                ).padding(10.dp).height(30.dp).width(120.dp).align(Alignment.CenterHorizontally),
+            Box(
+                modifier =
+                    Modifier.background(
+                            if (currentPageState.currentPage == index) Color.Magenta
+                            else Color.Transparent
+                        )
+                        .padding(10.dp)
+                        .height(30.dp)
+                        .width(120.dp)
+                        .align(Alignment.CenterHorizontally),
                 contentAlignment = Alignment.Center
             ) {
                 Text(

--- a/app/src/main/kotlin/view/tabScreen/SelectTabRow.kt
+++ b/app/src/main/kotlin/view/tabScreen/SelectTabRow.kt
@@ -1,0 +1,46 @@
+package view.tabScreen
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.material.Tab
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun SelectTabRow(currentPageState: PagerState, index: Int, coroutineScope: CoroutineScope, title: String) {
+    Tab(
+        selected = currentPageState.currentPage == index,
+        onClick = { coroutineScope.launch { currentPageState.animateScrollToPage(index) } },
+        modifier = Modifier,
+
+        content = {
+            Box(modifier = Modifier
+                .background(
+                    if (currentPageState.currentPage == index) Color.Magenta
+                    else Color.Transparent
+                ).padding(10.dp).height(30.dp).width(120.dp).align(Alignment.CenterHorizontally),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = title,
+                    textAlign = TextAlign.Center,
+                    color = if (currentPageState.currentPage == index) Color.White else Color.Black
+                    // Set text color for selected and unselected tabs
+                )
+            }
+        }
+    )
+}

--- a/app/src/main/kotlin/viewmodel/MainScreenViewModel.kt
+++ b/app/src/main/kotlin/viewmodel/MainScreenViewModel.kt
@@ -1,0 +1,5 @@
+package viewmodel
+
+import model.abstractGraph.Graph
+
+class MainScreenViewModel<D>(graph: Graph<D>) {}

--- a/app/src/main/kotlin/viewmodel/MainScreenViewModel.kt
+++ b/app/src/main/kotlin/viewmodel/MainScreenViewModel.kt
@@ -1,5 +1,21 @@
 package viewmodel
 
+import androidx.compose.runtime.mutableStateOf
 import model.abstractGraph.Graph
+import viewmodel.graph.GraphViewModel
+import viewmodel.graph.TestRepresentation
 
-class MainScreenViewModel<D>(graph: Graph<D>) {}
+class MainScreenViewModel<D>(graph: Graph<D>) {
+    val showVerticesData = mutableStateOf(false)
+    val showVerticesIds = mutableStateOf(false)
+    val graphViewModel = GraphViewModel(graph, showVerticesIds, showVerticesData)
+
+    init { // here will be a placement-function call
+        TestRepresentation().place(740.0, 650.0, graphViewModel.verticesVM)
+    }
+
+//    fun setEdgeColor
+//
+//    fun setVerticesColor()
+
+}

--- a/app/src/main/kotlin/viewmodel/MainScreenViewModel.kt
+++ b/app/src/main/kotlin/viewmodel/MainScreenViewModel.kt
@@ -1,6 +1,7 @@
 package viewmodel
 
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.unit.dp
 import model.abstractGraph.Graph
 import viewmodel.graph.GraphViewModel
 import viewmodel.graph.TestRepresentation
@@ -8,14 +9,20 @@ import viewmodel.graph.TestRepresentation
 class MainScreenViewModel<D>(graph: Graph<D>) {
     val showVerticesData = mutableStateOf(false)
     val showVerticesIds = mutableStateOf(false)
-    val graphViewModel = GraphViewModel(graph, showVerticesIds, showVerticesData)
+    val graphViewModel =
+        GraphViewModel(
+            graph,
+            showVerticesIds,
+            showVerticesData,
+            WindowViewModel(mutableStateOf(1200.dp), mutableStateOf(700.dp))
+        )
 
     init { // here will be a placement-function call
         TestRepresentation().place(740.0, 650.0, graphViewModel.verticesVM)
     }
 
-//    fun setEdgeColor
-//
-//    fun setVerticesColor()
+    //    fun setEdgeColor
+    //
+    //    fun setVerticesColor()
 
 }

--- a/app/src/main/kotlin/viewmodel/WindowViewModel.kt
+++ b/app/src/main/kotlin/viewmodel/WindowViewModel.kt
@@ -1,0 +1,30 @@
+package viewmodel
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.platform.LocalWindowInfo
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+class WindowViewModel(
+    private var height: MutableState<Dp> = mutableStateOf(0.dp),
+    private var width: MutableState<Dp> = mutableStateOf(0.dp),
+) {
+
+    @OptIn(ExperimentalComposeUiApi::class)
+    @Composable
+    fun SetCurrentDimensions() {
+        val configuration = LocalWindowInfo.current.containerSize
+        println(configuration)
+        height.value = configuration.height.dp
+        width.value = configuration.width.dp
+    }
+
+    val getHeight
+        get() = height.value
+
+    val getWidth
+        get() = width.value
+}

--- a/app/src/main/kotlin/viewmodel/graph/EdgeViewModel.kt
+++ b/app/src/main/kotlin/viewmodel/graph/EdgeViewModel.kt
@@ -1,0 +1,4 @@
+package viewmodel.graph
+
+class EdgeViewModel {
+}

--- a/app/src/main/kotlin/viewmodel/graph/EdgeViewModel.kt
+++ b/app/src/main/kotlin/viewmodel/graph/EdgeViewModel.kt
@@ -1,12 +1,9 @@
 package viewmodel.graph
 
-import androidx.compose.runtime.State
 import model.abstractGraph.Edge
-import model.abstractGraph.Vertex
 
 class EdgeViewModel<D>(
     val firstVertex: VertexViewModel<D>,
     val secondVertex: VertexViewModel<D>,
     private val currentEdge: Edge<D>, // do we really need it?
-) {
-}
+) {}

--- a/app/src/main/kotlin/viewmodel/graph/EdgeViewModel.kt
+++ b/app/src/main/kotlin/viewmodel/graph/EdgeViewModel.kt
@@ -1,4 +1,12 @@
 package viewmodel.graph
 
-class EdgeViewModel {
+import androidx.compose.runtime.State
+import model.abstractGraph.Edge
+import model.abstractGraph.Vertex
+
+class EdgeViewModel<D>(
+    val firstVertex: VertexViewModel<D>,
+    val secondVertex: VertexViewModel<D>,
+    private val currentEdge: Edge<D>, // do we really need it?
+) {
 }

--- a/app/src/main/kotlin/viewmodel/graph/GraphViewModel.kt
+++ b/app/src/main/kotlin/viewmodel/graph/GraphViewModel.kt
@@ -1,28 +1,37 @@
 package viewmodel.graph
 
 import androidx.compose.runtime.State
-import androidx.compose.ui.unit.dp
 import model.abstractGraph.Graph
+import viewmodel.WindowViewModel
 
 class GraphViewModel<D>(
     private val graph: Graph<D>,
     showIds: State<Boolean>,
     showVerticesData: State<Boolean>,
+    WindowVM: WindowViewModel,
 ) {
-    private val _verticesViewModels = graph.getVertices().associateWith { vertex ->
-        VertexViewModel(dataVisible = showVerticesData, idVisible = showIds, vertex = vertex)
-    }
+    private val _verticesViewModels =
+        graph.getVertices().associateWith { vertex ->
+            VertexViewModel(
+                dataVisible = showVerticesData,
+                idVisible = showIds,
+                vertex = vertex,
+                CurrentWindowVM = WindowVM
+            )
+        }
 
-    private val _edgeViewModels = graph.getEdges().associateWith { edge ->
+    private val _edgeViewModels =
+        graph.getEdges().associateWith { edge ->
+            val firstVertex: VertexViewModel<D> =
+                _verticesViewModels[edge.vertex1]
+                    ?: throw NoSuchElementException("No such View Model, with mentioned edges")
 
-        val firstVertex: VertexViewModel<D> = _verticesViewModels[edge.vertex1]
-            ?: throw NoSuchElementException("No such View Model, with mentioned edges")
+            val secondVertex: VertexViewModel<D> =
+                _verticesViewModels[edge.vertex1]
+                    ?: throw NoSuchElementException("No such View Model, with mentioned edges")
 
-        val secondVertex: VertexViewModel<D> = _verticesViewModels[edge.vertex1]
-            ?: throw NoSuchElementException("No such View Model, with mentioned edges")
-
-        EdgeViewModel(firstVertex, secondVertex, edge)
-    }
+            EdgeViewModel(firstVertex, secondVertex, edge)
+        }
 
     val verticesVM: Collection<VertexViewModel<D>>
         get() = _verticesViewModels.values

--- a/app/src/main/kotlin/viewmodel/graph/GraphViewModel.kt
+++ b/app/src/main/kotlin/viewmodel/graph/GraphViewModel.kt
@@ -1,0 +1,4 @@
+package viewmodel.graph
+
+class GraphViewModel {
+}

--- a/app/src/main/kotlin/viewmodel/graph/GraphViewModel.kt
+++ b/app/src/main/kotlin/viewmodel/graph/GraphViewModel.kt
@@ -10,7 +10,7 @@ class GraphViewModel<D>(
     showVerticesData: State<Boolean>,
 ) {
     private val _verticesViewModels = graph.getVertices().associateWith { vertex ->
-        VertexViewModel(0.dp, 0.dp, showVerticesData, showIds, vertex)
+        VertexViewModel(dataVisible = showVerticesData, idVisible = showIds, vertex = vertex)
     }
 
     private val _edgeViewModels = graph.getEdges().associateWith { edge ->

--- a/app/src/main/kotlin/viewmodel/graph/GraphViewModel.kt
+++ b/app/src/main/kotlin/viewmodel/graph/GraphViewModel.kt
@@ -1,4 +1,32 @@
 package viewmodel.graph
 
-class GraphViewModel {
+import androidx.compose.runtime.State
+import androidx.compose.ui.unit.dp
+import model.abstractGraph.Graph
+
+class GraphViewModel<D>(
+    private val graph: Graph<D>,
+    showIds: State<Boolean>,
+    showVerticesData: State<Boolean>,
+) {
+    private val _verticesViewModels = graph.getVertices().associateWith { vertex ->
+        VertexViewModel(0.dp, 0.dp, showVerticesData, showIds, vertex)
+    }
+
+    private val _edgeViewModels = graph.getEdges().associateWith { edge ->
+
+        val firstVertex: VertexViewModel<D> = _verticesViewModels[edge.vertex1]
+            ?: throw NoSuchElementException("No such View Model, with mentioned edges")
+
+        val secondVertex: VertexViewModel<D> = _verticesViewModels[edge.vertex1]
+            ?: throw NoSuchElementException("No such View Model, with mentioned edges")
+
+        EdgeViewModel(firstVertex, secondVertex, edge)
+    }
+
+    val verticesVM: Collection<VertexViewModel<D>>
+        get() = _verticesViewModels.values
+
+    val edgesVM: Collection<EdgeViewModel<D>>
+        get() = _edgeViewModels.values
 }

--- a/app/src/main/kotlin/viewmodel/graph/TestRepresentation.kt
+++ b/app/src/main/kotlin/viewmodel/graph/TestRepresentation.kt
@@ -1,6 +1,5 @@
 package viewmodel.graph
 
-import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.dp
 import kotlin.math.cos
 import kotlin.math.min
@@ -23,24 +22,26 @@ class TestRepresentation() {
         first.x.value = point.first.dp
         first.y.value = point.second.dp
 
-        sorted
-            .drop(1)
-            .onEach {
-                point = point.rotate(center, angle)
-                it.x.value = point.first.dp
-                it.y.value = point.second.dp
-            }
+        sorted.drop(1).onEach {
+            point = point.rotate(center, angle)
+            it.x.value = point.first.dp
+            it.y.value = point.second.dp
+        }
     }
 
-    private fun Pair<Double, Double>.rotate(pivot: Pair<Double, Double>, angle: Double): Pair<Double, Double> {
+    private fun Pair<Double, Double>.rotate(
+        pivot: Pair<Double, Double>,
+        angle: Double
+    ): Pair<Double, Double> {
         val sin = sin(angle)
         val cos = cos(angle)
 
         val diff = first - pivot.first to second - pivot.second
-        val rotated = Pair(
-            diff.first * cos - diff.second * sin,
-            diff.first * sin + diff.second * cos,
-        )
+        val rotated =
+            Pair(
+                diff.first * cos - diff.second * sin,
+                diff.first * sin + diff.second * cos,
+            )
         return rotated.first + pivot.first to rotated.second + pivot.second
     }
 }

--- a/app/src/main/kotlin/viewmodel/graph/TestRepresentation.kt
+++ b/app/src/main/kotlin/viewmodel/graph/TestRepresentation.kt
@@ -20,15 +20,15 @@ class TestRepresentation() {
         val sorted = vertices.sortedBy { it.getVertexData }
         val first = sorted.first()
         var point = Pair(center.first, center.second - min(width, height) / 2)
-        first.x = point.first.dp
-        first.y = point.second.dp
+        first.x.value = point.first.dp
+        first.y.value = point.second.dp
 
         sorted
             .drop(1)
             .onEach {
                 point = point.rotate(center, angle)
-                it.x = point.first.dp
-                it.y = point.second.dp
+                it.x.value = point.first.dp
+                it.y.value = point.second.dp
             }
     }
 

--- a/app/src/main/kotlin/viewmodel/graph/TestRepresentation.kt
+++ b/app/src/main/kotlin/viewmodel/graph/TestRepresentation.kt
@@ -1,0 +1,46 @@
+package viewmodel.graph
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.dp
+import kotlin.math.cos
+import kotlin.math.min
+import kotlin.math.sin
+
+class TestRepresentation() {
+
+    fun <V> place(width: Double, height: Double, vertices: Collection<VertexViewModel<V>>) {
+        if (vertices.isEmpty()) {
+            println("CircularPlacementStrategy.place: there is nothing to place 👐🏻")
+            return
+        }
+
+        val center = Pair(width / 2, height / 2)
+        val angle = 2 * Math.PI / vertices.size
+
+        val sorted = vertices.sortedBy { it.getVertexData }
+        val first = sorted.first()
+        var point = Pair(center.first, center.second - min(width, height) / 2)
+        first.x = point.first.dp
+        first.y = point.second.dp
+
+        sorted
+            .drop(1)
+            .onEach {
+                point = point.rotate(center, angle)
+                it.x = point.first.dp
+                it.y = point.second.dp
+            }
+    }
+
+    private fun Pair<Double, Double>.rotate(pivot: Pair<Double, Double>, angle: Double): Pair<Double, Double> {
+        val sin = sin(angle)
+        val cos = cos(angle)
+
+        val diff = first - pivot.first to second - pivot.second
+        val rotated = Pair(
+            diff.first * cos - diff.second * sin,
+            diff.first * sin + diff.second * cos,
+        )
+        return rotated.first + pivot.first to rotated.second + pivot.second
+    }
+}

--- a/app/src/main/kotlin/viewmodel/graph/VertexViewModel.kt
+++ b/app/src/main/kotlin/viewmodel/graph/VertexViewModel.kt
@@ -3,12 +3,11 @@ package viewmodel.graph
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import model.abstractGraph.Vertex
-
+import viewmodel.WindowViewModel
 
 class VertexViewModel<D>(
     var x: MutableState<Dp> = mutableStateOf(0.dp),
@@ -16,6 +15,7 @@ class VertexViewModel<D>(
     var dataVisible: State<Boolean>,
     var idVisible: State<Boolean>,
     private val vertex: Vertex<D>,
+    val CurrentWindowVM: WindowViewModel,
     val radius: Dp = 30.dp,
 ) {
     var isSelected = mutableStateOf(false)
@@ -24,7 +24,13 @@ class VertexViewModel<D>(
         get() = vertex.data.toString()
 
     fun onDrag(dragAmount: DpOffset) {
-        x.value += dragAmount.x
-        y.value += dragAmount.y
+
+        if (x.value + dragAmount.x > CurrentWindowVM.getWidth)
+            x.value = CurrentWindowVM.getWidth - radius
+        else x.value += dragAmount.x
+
+        if (y.value + dragAmount.y > CurrentWindowVM.getWidth)
+            y.value = CurrentWindowVM.getWidth - radius
+        else y.value += dragAmount.y
     }
 }

--- a/app/src/main/kotlin/viewmodel/graph/VertexViewModel.kt
+++ b/app/src/main/kotlin/viewmodel/graph/VertexViewModel.kt
@@ -1,6 +1,8 @@
 package viewmodel.graph
 
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
@@ -9,20 +11,20 @@ import model.abstractGraph.Vertex
 
 
 class VertexViewModel<D>(
-    var x: Dp = 0.dp,
-    var y: Dp = 0.dp,
+    var x: MutableState<Dp> = mutableStateOf(0.dp),
+    var y: MutableState<Dp> = mutableStateOf(0.dp),
     var dataVisible: State<Boolean>,
-    var idVisble: State<Boolean>,
+    var idVisible: State<Boolean>,
     private val vertex: Vertex<D>,
     val radius: Dp = 30.dp,
 ) {
-    var isSelected = false
+    var isSelected = mutableStateOf(false)
 
     val getVertexData
         get() = vertex.data.toString()
 
     fun onDrag(dragAmount: DpOffset) {
-        x += dragAmount.x
-        y += dragAmount.y
+        x.value += dragAmount.x
+        y.value += dragAmount.y
     }
 }

--- a/app/src/main/kotlin/viewmodel/graph/VertexViewModel.kt
+++ b/app/src/main/kotlin/viewmodel/graph/VertexViewModel.kt
@@ -1,4 +1,28 @@
 package viewmodel.graph
 
-class VertexViewModel {
+import androidx.compose.runtime.State
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.dp
+import model.abstractGraph.Vertex
+
+
+class VertexViewModel<D>(
+    var x: Dp = 0.dp,
+    var y: Dp = 0.dp,
+    var dataVisible: State<Boolean>,
+    var idVisble: State<Boolean>,
+    private val vertex: Vertex<D>,
+    val radius: Dp = 30.dp,
+) {
+    var isSelected = false
+
+    val getVertexData
+        get() = vertex.data.toString()
+
+    fun onDrag(dragAmount: DpOffset) {
+        x += dragAmount.x
+        y += dragAmount.y
+    }
 }

--- a/app/src/main/kotlin/viewmodel/graph/VertexViewModel.kt
+++ b/app/src/main/kotlin/viewmodel/graph/VertexViewModel.kt
@@ -1,0 +1,4 @@
+package viewmodel.graph
+
+class VertexViewModel {
+}


### PR DESCRIPTION
#### Implement initial UI with TabRow-menu and surface for graph representation.

### Due to chosen MVVM structure - created **view** package, that consists of: 
-  _graph package_
Objects that represent the graph in a surface.

- _tabScreen package_ 
Stores different menu 'pages': general, analyse, and file-control.  

- _MainScreen_ 
File that implements the main screen's 'markup', that controls the placement of all visible ui-elements. In future - it is better to abstract significant code parts)

### and **viewmodel** package:
- _graph ViewModels_
Middle layer, that is used to store data of 'ui' elements and some control-based methods, affecting element's data, which is directly related to UI view.

- _MainScreenViewModel_
Just a wrap.

### TODO:
- determine more user-friendly tab titles
- make graph's nodes undraggable out of the window border, 
- fix UI's colors 
- mb make tab row closable and adjustable by user?
- highlight vertex/edge if picked
- menu!
- more abstract!
