### PR TITLE
Add tests for abstract graph basic methods

### DIFF
--- a/app/src/main/kotlin/model/abstractGraph/Edge.kt
+++ b/app/src/main/kotlin/model/abstractGraph/Edge.kt
@@ -1,6 +1,7 @@
 package model.abstractGraph
 
 class Edge<D>(val vertex1: Vertex<D>, val vertex2: Vertex<D>) {
-
     fun isIncident(vertex: Vertex<D>) = (vertex1 == vertex || vertex2 == vertex)
+
+    override fun equals(other: Any?) = (other is Edge<*>) && (vertex1 == other.vertex1) && (vertex2 == other.vertex2)
 }

--- a/app/src/main/kotlin/model/abstractGraph/Edge.kt
+++ b/app/src/main/kotlin/model/abstractGraph/Edge.kt
@@ -2,6 +2,4 @@ package model.abstractGraph
 
 class Edge<D>(val vertex1: Vertex<D>, val vertex2: Vertex<D>) {
     fun isIncident(vertex: Vertex<D>) = (vertex1 == vertex || vertex2 == vertex)
-
-    override fun equals(other: Any?) = (other is Edge<*>) && (vertex1 == other.vertex1) && (vertex2 == other.vertex2)
 }

--- a/app/src/main/kotlin/model/abstractGraph/Graph.kt
+++ b/app/src/main/kotlin/model/abstractGraph/Graph.kt
@@ -80,20 +80,19 @@ abstract class Graph<D> {
 
     fun getVertices() = vertices.toList()
 
-    // This and next two methods are used to localize exceptions
-    protected fun getNeighbours(vertex: Vertex<D>): ArrayList<Vertex<D>> {
+    fun getNeighbours(vertex: Vertex<D>): ArrayList<Vertex<D>> {
         val neighbours = adjacencyMap[vertex]
             ?: throw NoSuchElementException("Vertex with id ${vertex.id} is not present in the adjacency map.")
 
         return neighbours
     }
 
-    protected fun getOutgoingEdges(vertex: Vertex<D>): ArrayList<Edge<D>> {
+    fun getOutgoingEdges(vertex: Vertex<D>): ArrayList<Edge<D>> {
         val outgoingEdges = outgoingEdgesMap[vertex]
             ?: throw NoSuchElementException("Vertex with id ${vertex.id} is not present in the outgoing edges map.")
 
         return outgoingEdges
     }
 
-    protected abstract fun getEdge(vertex1: Vertex<D>, vertex2: Vertex<D>): Edge<D>
+    abstract fun getEdge(vertex1: Vertex<D>, vertex2: Vertex<D>): Edge<D>
 }

--- a/app/src/main/kotlin/model/abstractGraph/Vertex.kt
+++ b/app/src/main/kotlin/model/abstractGraph/Vertex.kt
@@ -1,5 +1,3 @@
 package model.abstractGraph
 
-class Vertex<D>(val id: Int, val data: D) {
-    override fun equals(other: Any?) = (other is Vertex<*>) && (id == other.id) && (data == other.data)
-}
+class Vertex<D>(val id: Int, val data: D)

--- a/app/src/main/kotlin/model/abstractGraph/Vertex.kt
+++ b/app/src/main/kotlin/model/abstractGraph/Vertex.kt
@@ -1,3 +1,5 @@
 package model.abstractGraph
 
-class Vertex<D>(val id: Int, val data: D)
+class Vertex<D>(val id: Int, val data: D) {
+    override fun equals(other: Any?) = (other is Vertex<*>) && (id == other.id) && (data == other.data)
+}

--- a/app/src/test/kotlin/model/abstractGraph/GraphTest.kt
+++ b/app/src/test/kotlin/model/abstractGraph/GraphTest.kt
@@ -1,5 +1,6 @@
 package model.abstractGraph
 
+import model.abstractGraph.Graph
 import model.DirectedGraph
 import model.UndirectedGraph
 import model.WeightedDirectedGraph
@@ -25,6 +26,24 @@ fun provideAllGraphTypes(): Stream<Arguments> {
         Arguments.of(WeightedDirectedGraph<Int>()),
         Arguments.of(WeightedUndirectedGraph<Int>())
     )
+}
+
+fun setup(graph: Graph<Int>): Graph<Int> {
+    graph.apply {
+        val v0 = addVertex(0)
+        val v1 = addVertex(1)
+        val v2 = addVertex(2)
+        val v3 = addVertex(3)
+        val v4 = addVertex(4)
+
+        addEdge(v0, v1)
+        addEdge(v1, v2)
+        addEdge(v2, v3)
+        addEdge(v3, v4)
+        addEdge(v4, v1)
+    }
+
+    return graph
 }
 
 class GraphTest {

--- a/app/src/test/kotlin/model/abstractGraph/GraphTest.kt
+++ b/app/src/test/kotlin/model/abstractGraph/GraphTest.kt
@@ -6,19 +6,21 @@ import model.WeightedDirectedGraph
 import model.WeightedUndirectedGraph
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.extension.ExtensionContext
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
-import org.junit.jupiter.params.provider.MethodSource
+import org.junit.jupiter.params.provider.ArgumentsProvider
+import org.junit.jupiter.params.provider.ArgumentsSource
 import java.util.stream.Stream
 
-@ParameterizedTest
-@MethodSource("provideAllGraphTypes")
+@ParameterizedTest(name = "{0}")
+@ArgumentsSource(AllGraphTypesProvider::class)
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)
 private annotation class TestAllGraphTypes
 
-fun provideAllGraphTypes(): Stream<Arguments> {
-    return Stream.of(
+class AllGraphTypesProvider : ArgumentsProvider {
+    override fun provideArguments(context: ExtensionContext?) = Stream.of(
         Arguments.of(UndirectedGraph<Int>()),
         Arguments.of(DirectedGraph<Int>()),
         Arguments.of(WeightedDirectedGraph<Int>()),
@@ -284,6 +286,7 @@ class GraphTest {
                 }
             }
 
+            @TestAllGraphTypes
             fun `removing vertex with wrong data should cause exception`(graph: Graph<Int>) {
                 setup(graph)
 

--- a/app/src/test/kotlin/model/abstractGraph/GraphTest.kt
+++ b/app/src/test/kotlin/model/abstractGraph/GraphTest.kt
@@ -60,7 +60,6 @@ class GraphTest {
             fun `non-empty list of vertices should be returned`(graph: Graph<Int>) {
                 val graphStructure = setup(graph)
                 val defaultVerticesList = graphStructure.first
-                val defaultEdgesSet = graphStructure.second
 
                 val actualList = graph.getVertices()
                 val expectedList = defaultVerticesList
@@ -71,13 +70,11 @@ class GraphTest {
             @TestAllGraphTypes
             fun `graph should not change`(graph: Graph<Int>) {
                 val graphStructure = setup(graph)
-                val defaultVerticesList = graphStructure.first
-                val defaultEdgesSet = graphStructure.second
 
                 graph.getVertices()
 
                 val actualGraph = graph.getVertices() to graph.getEdges().toSet()
-                val expectedGraph = defaultVerticesList to defaultEdgesSet
+                val expectedGraph = graphStructure
 
                 assertEquals(expectedGraph, actualGraph)
             }
@@ -112,7 +109,6 @@ class GraphTest {
             @TestAllGraphTypes
             fun `non-empty list of edges should be returned`(graph: Graph<Int>) {
                 val graphStructure = setup(graph)
-                val defaultVerticesList = graphStructure.first
                 val defaultEdgesSet = graphStructure.second
 
                 val actualSet = graph.getEdges().toSet()
@@ -124,13 +120,11 @@ class GraphTest {
             @TestAllGraphTypes
             fun `graph should not change`(graph: Graph<Int>) {
                 val graphStructure = setup(graph)
-                val defaultVerticesList = graphStructure.first
-                val defaultEdgesSet = graphStructure.second
 
                 graph.getEdges()
 
                 val actualGraph = graph.getVertices() to graph.getEdges().toSet()
-                val expectedGraph = defaultVerticesList to defaultEdgesSet
+                val expectedGraph = graphStructure
 
                 assertEquals(expectedGraph, actualGraph)
             }
@@ -190,7 +184,6 @@ class GraphTest {
             fun `removed vertex should be returned`(graph: Graph<Int>) {
                 val graphStructure = setup(graph)
                 val defaultVerticesList = graphStructure.first
-                val defaultEdgesSet = graphStructure.second
 
                 val returnedVertex = graph.removeVertex(defaultVerticesList[2])
 
@@ -201,7 +194,6 @@ class GraphTest {
             fun `vertex added after removal should have right id`(graph: Graph<Int>) {
                 val graphStructure = setup(graph)
                 val defaultVerticesList = graphStructure.first
-                val defaultEdgesSet = graphStructure.second
 
                 graph.removeVertex(defaultVerticesList[3])
                 val newVertex = graph.addVertex(5)
@@ -215,7 +207,6 @@ class GraphTest {
                 fun `vertex should be removed from vertices list`(graph: Graph<Int>) {
                     val graphStructure = setup(graph)
                     val defaultVerticesList = graphStructure.first
-                    val defaultEdgesSet = graphStructure.second
 
                     val removedVertex = graph.removeVertex(defaultVerticesList[4])
 
@@ -255,7 +246,6 @@ class GraphTest {
                 fun `last added vertex should be moved to removed vertex's place`(graph: Graph<Int>) {
                     val graphStructure = setup(graph)
                     val defaultVerticesList = graphStructure.first
-                    val defaultEdgesSet = graphStructure.second
 
                     val oldV0 = defaultVerticesList[0]
                     val oldV1 = defaultVerticesList[1]
@@ -284,7 +274,6 @@ class GraphTest {
                 fun `last added vertex's incident edges should change`(graph: Graph<Int>) {
                     val graphStructure = setup(graph)
                     val defaultVerticesList = graphStructure.first
-                    val defaultEdgesSet = graphStructure.second
 
                     val oldV0 = defaultVerticesList[0]
                     val oldV1 = defaultVerticesList[1]
@@ -324,7 +313,7 @@ class GraphTest {
 
             @TestAllGraphTypes
             fun `removing non-existing vertex from a non-empty graph should cause exception`(graph: Graph<Int>) {
-                val graphStructure = setup(graph)
+                setup(graph)
 
                 assertThrows(NoSuchElementException::class.java) {
                     graph.removeVertex(Vertex(1904,-360))
@@ -333,7 +322,7 @@ class GraphTest {
 
             @TestAllGraphTypes
             fun `removing vertex with wrong id should cause exception`(graph: Graph<Int>) {
-                val graphStructure = setup(graph)
+                setup(graph)
 
                 assertThrows(NoSuchElementException::class.java) {
                     graph.removeVertex(Vertex(6,3))
@@ -342,7 +331,7 @@ class GraphTest {
 
             @TestAllGraphTypes
             fun `removing vertex with wrong data should cause exception`(graph: Graph<Int>) {
-                val graphStructure = setup(graph)
+                setup(graph)
 
                 assertThrows(NoSuchElementException::class.java) {
                     graph.removeVertex(Vertex(0,35))

--- a/app/src/test/kotlin/model/abstractGraph/GraphTest.kt
+++ b/app/src/test/kotlin/model/abstractGraph/GraphTest.kt
@@ -52,7 +52,7 @@ val v4 = Vertex(4, 4)
 
 val defaultVertices = listOf(v0, v1, v2, v3, v4)
 
-val defaultEdges = setOf(
+val defaultEdgesSet = setOf(
     Edge(v0, v1),
     Edge(v1, v2),
     Edge(v2, v3),
@@ -79,7 +79,7 @@ class GraphTest {
                 setup(graph)
 
                 val actualGraph = graph.getVertices() to graph.getEdges().toSet()
-                val expectedGraph = defaultVertices to defaultEdges
+                val expectedGraph = defaultVertices to defaultEdgesSet
 
                 assertEquals(expectedGraph, actualGraph)
             }
@@ -97,7 +97,7 @@ class GraphTest {
             @TestAllGraphTypes
             fun `graph should not change`(graph: Graph<Int>) {
                 val actualGraph = graph.getVertices() to graph.getEdges().toSet()
-                val expectedGraph = defaultVertices to defaultEdges
+                val expectedGraph = defaultVertices to defaultEdgesSet
 
                 assertEquals(expectedGraph, actualGraph)
             }
@@ -112,7 +112,7 @@ class GraphTest {
                 setup(graph)
 
                 val actualSet = graph.getEdges().toSet()
-                val expectedSet = defaultEdges
+                val expectedSet = defaultEdgesSet
 
                 assertEquals(expectedSet, actualSet)
             }
@@ -122,7 +122,7 @@ class GraphTest {
                 setup(graph)
 
                 val actualGraph = graph.getVertices() to graph.getEdges().toSet()
-                val expectedGraph = defaultVertices to defaultEdges
+                val expectedGraph = defaultVertices to defaultEdgesSet
 
                 assertEquals(expectedGraph, actualGraph)
             }
@@ -132,7 +132,7 @@ class GraphTest {
             @TestAllGraphTypes
             fun `empty list is should be returned`(graph: Graph<Int>) {
                 val actualSet = graph.getEdges().toSet()
-                val expectedSet = defaultEdges
+                val expectedSet = defaultEdgesSet
 
                 assertEquals(expectedSet, actualSet)
             }
@@ -140,7 +140,7 @@ class GraphTest {
             @TestAllGraphTypes
             fun `graph should not change`(graph: Graph<Int>) {
                 val actualGraph = graph.getVertices() to graph.getEdges().toSet()
-                val expectedGraph = defaultVertices to defaultEdges
+                val expectedGraph = defaultVertices to defaultEdgesSet
 
                 assertEquals(expectedGraph, actualGraph)
             }
@@ -148,7 +148,26 @@ class GraphTest {
     }
 
     @Nested
-    inner class AddVertexTest {}
+    inner class AddVertexTest {
+        @TestAllGraphTypes
+        fun `added vertex should be returned`(graph: Graph<Int>) {
+            val actualValue = graph.addVertex(0)
+            val expectedValue = Vertex(0, 0)
+
+            assertEquals(expectedValue, actualValue)
+        }
+
+        @TestAllGraphTypes
+        fun `vertex should be added to graph`(graph: Graph<Int>) {
+            setup(graph)
+            graph.addVertex(5)
+
+            val actualGraph = graph.getVertices() to graph.getEdges().toSet()
+            val expectedGraph = (defaultVertices + Vertex(5, 5)) to defaultEdgesSet
+
+            assertEquals(expectedGraph, actualGraph)
+        }
+    }
 
     @Nested
     inner class RemoveVertexTest {}

--- a/app/src/test/kotlin/model/abstractGraph/GraphTest.kt
+++ b/app/src/test/kotlin/model/abstractGraph/GraphTest.kt
@@ -23,8 +23,8 @@ class AllGraphTypesProvider : ArgumentsProvider {
     override fun provideArguments(context: ExtensionContext?): Stream<Arguments> = Stream.of(
         Arguments.of(UndirectedGraph<Int>()),
         Arguments.of(DirectedGraph<Int>()),
-        Arguments.of(WeightedDirectedGraph<Int>()),
-        Arguments.of(WeightedUndirectedGraph<Int>())
+        Arguments.of(WeightedUndirectedGraph<Int>()),
+        Arguments.of(WeightedDirectedGraph<Int>())
     )
 }
 
@@ -294,7 +294,7 @@ class GraphTest {
                     val expectedEdges = setOf(
                         graph.getEdge(newV0, newV1),
                         graph.getEdge(newV3, newV2),
-                        graph.addEdge(newV2, newV1)
+                        graph.getEdge(newV2, newV1)
                     )
 
                     assertEquals(expectedEdges, actualEdges)

--- a/app/src/test/kotlin/model/abstractGraph/GraphTest.kt
+++ b/app/src/test/kotlin/model/abstractGraph/GraphTest.kt
@@ -217,7 +217,7 @@ class GraphTest {
                     val defaultVerticesList = graphStructure.first
                     val defaultEdgesSet = graphStructure.second
 
-                    val removedVertex = graph.removeVertex(defaultVerticesList[3])
+                    val removedVertex = graph.removeVertex(defaultVerticesList[4])
 
                     val actualVertices = graph.getVertices()
                     val expectedVertices = defaultVerticesList - removedVertex
@@ -237,10 +237,13 @@ class GraphTest {
                     val v3 = defaultVerticesList[3]
                     val v4 = defaultVerticesList[4]
 
+                    val e0 = graph.getEdge(v3, v4)
+                    val e1 = graph.getEdge(v4, v1)
+
                     graph.removeVertex(v4)
 
                     val actualEdges = graph.getEdges().toSet()
-                    val expectedEdges = defaultEdgesSet - graph.getEdge(v3, v4) - graph.getEdge(v4, v1)
+                    val expectedEdges = defaultEdgesSet - e0 - e1
 
                     assertEquals(expectedEdges, actualEdges)
                 }

--- a/app/src/test/kotlin/model/abstractGraph/GraphTest.kt
+++ b/app/src/test/kotlin/model/abstractGraph/GraphTest.kt
@@ -20,7 +20,7 @@ import java.util.stream.Stream
 private annotation class TestAllGraphTypes
 
 class AllGraphTypesProvider : ArgumentsProvider {
-    override fun provideArguments(context: ExtensionContext?) = Stream.of(
+    override fun provideArguments(context: ExtensionContext?): Stream<Arguments> = Stream.of(
         Arguments.of(UndirectedGraph<Int>()),
         Arguments.of(DirectedGraph<Int>()),
         Arguments.of(WeightedDirectedGraph<Int>()),
@@ -28,35 +28,28 @@ class AllGraphTypesProvider : ArgumentsProvider {
     )
 }
 
-fun setup(graph: Graph<Int>) = graph.apply {
-        val v0 = addVertex(0)
-        val v1 = addVertex(1)
-        val v2 = addVertex(2)
-        val v3 = addVertex(3)
-        val v4 = addVertex(4)
+fun setup(graph: Graph<Int>): Pair<List<Vertex<Int>>, Set<Edge<Int>>> {
+    val v0 = graph.addVertex(0)
+    val v1 = graph.addVertex(1)
+    val v2 = graph.addVertex(2)
+    val v3 = graph.addVertex(3)
+    val v4 = graph.addVertex(4)
 
-        addEdge(v0, v1)
-        addEdge(v1, v2)
-        addEdge(v2, v3)
-        addEdge(v3, v4)
-        addEdge(v4, v1)
+    val defaultVerticesList = listOf(v0, v1, v2, v3, v4)
+
+    val defaultEdgesSet = setOf(
+        graph.addEdge(v0, v1),
+        graph.addEdge(v1, v2),
+        graph.addEdge(v2, v3),
+        graph.addEdge(v3, v4),
+        graph.addEdge(v4, v1)
+    )
+
+    return defaultVerticesList to defaultEdgesSet
 }
 
-val v0 = Vertex(0, 0)
-val v1 = Vertex(1, 1)
-val v2 = Vertex(2, 2)
-val v3 = Vertex(3, 3)
-val v4 = Vertex(4, 4)
-
-val defaultVertices = listOf(v0, v1, v2, v3, v4)
-
-val defaultEdgesSet = setOf(
-    Edge(v0, v1),
-    Edge(v1, v2),
-    Edge(v2, v3),
-    Edge(v3, v4),
-    Edge(v4, v1)
-)
+val emptyVerticesList = listOf<Vertex<Int>>()
+val emptyEdgesSet = setOf<Edge<Int>>()
 
 class GraphTest {
     @Nested
@@ -65,20 +58,26 @@ class GraphTest {
         inner class `Graph is not empty` {
             @TestAllGraphTypes
             fun `non-empty list of vertices should be returned`(graph: Graph<Int>) {
-                setup(graph)
+                val graphStructure = setup(graph)
+                val defaultVerticesList = graphStructure.first
+                val defaultEdgesSet = graphStructure.second
 
                 val actualList = graph.getVertices()
-                val expectedList = defaultVertices
+                val expectedList = defaultVerticesList
 
                 assertEquals(expectedList, actualList)
             }
 
             @TestAllGraphTypes
             fun `graph should not change`(graph: Graph<Int>) {
-                setup(graph)
+                val graphStructure = setup(graph)
+                val defaultVerticesList = graphStructure.first
+                val defaultEdgesSet = graphStructure.second
+
+                graph.getVertices()
 
                 val actualGraph = graph.getVertices() to graph.getEdges().toSet()
-                val expectedGraph = defaultVertices to defaultEdgesSet
+                val expectedGraph = defaultVerticesList to defaultEdgesSet
 
                 assertEquals(expectedGraph, actualGraph)
             }
@@ -96,8 +95,10 @@ class GraphTest {
 
             @TestAllGraphTypes
             fun `empty graph should not change`(graph: Graph<Int>) {
+                graph.getVertices()
+
                 val actualGraph = graph.getVertices() to graph.getEdges().toSet()
-                val expectedGraph = defaultVertices to defaultEdgesSet
+                val expectedGraph = emptyVerticesList to emptyEdgesSet
 
                 assertEquals(expectedGraph, actualGraph)
             }
@@ -110,7 +111,9 @@ class GraphTest {
         inner class `Graph is not empty` {
             @TestAllGraphTypes
             fun `non-empty list of edges should be returned`(graph: Graph<Int>) {
-                setup(graph)
+                val graphStructure = setup(graph)
+                val defaultVerticesList = graphStructure.first
+                val defaultEdgesSet = graphStructure.second
 
                 val actualSet = graph.getEdges().toSet()
                 val expectedSet = defaultEdgesSet
@@ -120,10 +123,14 @@ class GraphTest {
 
             @TestAllGraphTypes
             fun `graph should not change`(graph: Graph<Int>) {
-                setup(graph)
+                val graphStructure = setup(graph)
+                val defaultVerticesList = graphStructure.first
+                val defaultEdgesSet = graphStructure.second
+
+                graph.getEdges()
 
                 val actualGraph = graph.getVertices() to graph.getEdges().toSet()
-                val expectedGraph = defaultVertices to defaultEdgesSet
+                val expectedGraph = defaultVerticesList to defaultEdgesSet
 
                 assertEquals(expectedGraph, actualGraph)
             }
@@ -134,15 +141,17 @@ class GraphTest {
             @TestAllGraphTypes
             fun `empty list should be returned`(graph: Graph<Int>) {
                 val actualSet = graph.getEdges().toSet()
-                val expectedSet = defaultEdgesSet
+                val expectedSet = emptyEdgesSet
 
                 assertEquals(expectedSet, actualSet)
             }
 
             @TestAllGraphTypes
             fun `empty graph should not change`(graph: Graph<Int>) {
+                graph.getEdges()
+
                 val actualGraph = graph.getVertices() to graph.getEdges().toSet()
-                val expectedGraph = defaultVertices to defaultEdgesSet
+                val expectedGraph = emptyVerticesList to emptyEdgesSet
 
                 assertEquals(expectedGraph, actualGraph)
             }
@@ -153,19 +162,21 @@ class GraphTest {
     inner class AddVertexTest {
         @TestAllGraphTypes
         fun `added vertex should be returned`(graph: Graph<Int>) {
-            val actualValue = graph.addVertex(0)
-            val expectedValue = Vertex(0, 0)
+            val returnedVertex = graph.addVertex(0)
 
-            assertEquals(expectedValue, actualValue)
+            assertTrue(returnedVertex.id == 0 && returnedVertex.data == 0)
         }
 
         @TestAllGraphTypes
         fun `vertex should be added to graph`(graph: Graph<Int>) {
-            setup(graph)
-            graph.addVertex(5)
+            val graphStructure = setup(graph)
+            val defaultVerticesList = graphStructure.first
+            val defaultEdgesSet = graphStructure.second
+
+            val newVertex = graph.addVertex(5)
 
             val actualGraph = graph.getVertices() to graph.getEdges().toSet()
-            val expectedGraph = (defaultVertices + Vertex(5, 5)) to defaultEdgesSet
+            val expectedGraph = (defaultVerticesList + newVertex) to defaultEdgesSet
 
             assertEquals(expectedGraph, actualGraph)
         }
@@ -177,46 +188,59 @@ class GraphTest {
         inner class `Vertex is in the graph` {
             @TestAllGraphTypes
             fun `removed vertex should be returned`(graph: Graph<Int>) {
-                setup(graph)
+                val graphStructure = setup(graph)
+                val defaultVerticesList = graphStructure.first
+                val defaultEdgesSet = graphStructure.second
 
-                val actualValue = graph.removeVertex(v2)
-                val expectedValue = v2
+                val returnedVertex = graph.removeVertex(defaultVerticesList[2])
 
-                assertEquals(expectedValue, actualValue)
+                assertTrue(returnedVertex.id == 2 && returnedVertex.data == 2)
             }
 
             @TestAllGraphTypes
             fun `vertex added after removal should have right id`(graph: Graph<Int>) {
-                setup(graph)
-                graph.removeVertex(v3)
+                val graphStructure = setup(graph)
+                val defaultVerticesList = graphStructure.first
+                val defaultEdgesSet = graphStructure.second
+
+                graph.removeVertex(defaultVerticesList[3])
                 val newVertex = graph.addVertex(5)
 
-                val actualId = newVertex.id
-                val expectedId = 4
-
-                assertEquals(expectedId, actualId)
+                assertTrue(newVertex.id == 4)
             }
 
             @Nested
             inner class `Vertex is last` {
                 @TestAllGraphTypes
                 fun `vertex should be removed from vertices list`(graph: Graph<Int>) {
-                    setup(graph)
-                    graph.removeVertex(v3)
+                    val graphStructure = setup(graph)
+                    val defaultVerticesList = graphStructure.first
+                    val defaultEdgesSet = graphStructure.second
+
+                    val removedVertex = graph.removeVertex(defaultVerticesList[3])
 
                     val actualVertices = graph.getVertices()
-                    val expectedVertices = defaultVertices - v3
+                    val expectedVertices = defaultVerticesList - removedVertex
 
                     assertEquals(expectedVertices, actualVertices)
                 }
 
                 @TestAllGraphTypes
                 fun `incident edges should be removed`(graph: Graph<Int>) {
-                    setup(graph)
+                    val graphStructure = setup(graph)
+                    val defaultVerticesList = graphStructure.first
+                    val defaultEdgesSet = graphStructure.second
+
+                    val v0 = defaultVerticesList[0]
+                    val v1 = defaultVerticesList[1]
+                    val v2 = defaultVerticesList[2]
+                    val v3 = defaultVerticesList[3]
+                    val v4 = defaultVerticesList[4]
+
                     graph.removeVertex(v4)
 
                     val actualEdges = graph.getEdges().toSet()
-                    val expectedEdges = defaultEdgesSet - Edge(v3, v4) - Edge(v4, v1)
+                    val expectedEdges = defaultEdgesSet - graph.getEdge(v3, v4) - graph.getEdge(v4, v1)
 
                     assertEquals(expectedEdges, actualEdges)
                 }
@@ -226,32 +250,59 @@ class GraphTest {
             inner class `Vertex isn't last` {
                 @TestAllGraphTypes
                 fun `last added vertex should be moved to removed vertex's place`(graph: Graph<Int>) {
-                    setup(graph)
-                    graph.removeVertex(v2)
+                    val graphStructure = setup(graph)
+                    val defaultVerticesList = graphStructure.first
+                    val defaultEdgesSet = graphStructure.second
 
-                    val actualVertices = graph.getVertices()
-                    val expectedVertices = listOf(
-                        Vertex(0, 0),
-                        Vertex(1, 1),
-                        Vertex(2, 4),
-                        Vertex(3, 3),
+                    val oldV0 = defaultVerticesList[0]
+                    val oldV1 = defaultVerticesList[1]
+                    val oldV2 = defaultVerticesList[2]
+                    val oldV3 = defaultVerticesList[3]
+                    val oldV4 = defaultVerticesList[4]
+
+                    graph.removeVertex(oldV2)
+
+                    val newVertices = graph.getVertices()
+
+                    val newV0 = newVertices[0]
+                    val newV1 = newVertices[1]
+                    val newV2 = newVertices[2]
+                    val newV3 = newVertices[3]
+
+                    assertTrue(
+                        newV0 == oldV0 &&
+                        newV1 == oldV1 &&
+                        newV2.id == 2 && newV2.data == 4 &&
+                        newV3 == oldV3
                     )
-
-                    assertEquals(expectedVertices, actualVertices)
                 }
 
                 @TestAllGraphTypes
                 fun `last added vertex's incident edges should change`(graph: Graph<Int>) {
-                    setup(graph)
-                    graph.removeVertex(v2)
+                    val graphStructure = setup(graph)
+                    val defaultVerticesList = graphStructure.first
+                    val defaultEdgesSet = graphStructure.second
 
-                    val v4Copy = Vertex(2, 4)
+                    val oldV0 = defaultVerticesList[0]
+                    val oldV1 = defaultVerticesList[1]
+                    val oldV2 = defaultVerticesList[2]
+                    val oldV3 = defaultVerticesList[3]
+                    val oldV4 = defaultVerticesList[4]
+
+                    graph.removeVertex(oldV2)
+
+                    val newVertices = graph.getVertices()
+
+                    val newV0 = newVertices[0]
+                    val newV1 = newVertices[1]
+                    val newV2 = newVertices[2]
+                    val newV3 = newVertices[3]
 
                     val actualEdges = graph.getEdges().toSet()
                     val expectedEdges = setOf(
-                        Edge(v0, v1),
-                        Edge(v3, v4Copy),
-                        Edge(v4Copy, v1)
+                        graph.getEdge(newV0, newV1),
+                        graph.getEdge(newV3, newV2),
+                        graph.addEdge(newV2, newV1)
                     )
 
                     assertEquals(expectedEdges, actualEdges)
@@ -270,7 +321,7 @@ class GraphTest {
 
             @TestAllGraphTypes
             fun `removing non-existing vertex from a non-empty graph should cause exception`(graph: Graph<Int>) {
-                setup(graph)
+                val graphStructure = setup(graph)
 
                 assertThrows(NoSuchElementException::class.java) {
                     graph.removeVertex(Vertex(1904,-360))
@@ -279,7 +330,7 @@ class GraphTest {
 
             @TestAllGraphTypes
             fun `removing vertex with wrong id should cause exception`(graph: Graph<Int>) {
-                setup(graph)
+                val graphStructure = setup(graph)
 
                 assertThrows(NoSuchElementException::class.java) {
                     graph.removeVertex(Vertex(6,3))
@@ -288,7 +339,7 @@ class GraphTest {
 
             @TestAllGraphTypes
             fun `removing vertex with wrong data should cause exception`(graph: Graph<Int>) {
-                setup(graph)
+                val graphStructure = setup(graph)
 
                 assertThrows(NoSuchElementException::class.java) {
                     graph.removeVertex(Vertex(0,35))

--- a/app/src/test/kotlin/model/abstractGraph/GraphTest.kt
+++ b/app/src/test/kotlin/model/abstractGraph/GraphTest.kt
@@ -1,13 +1,11 @@
 package model.abstractGraph
 
-import model.abstractGraph.Graph
 import model.DirectedGraph
 import model.UndirectedGraph
 import model.WeightedDirectedGraph
 import model.WeightedUndirectedGraph
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Nested
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
@@ -46,12 +44,108 @@ fun setup(graph: Graph<Int>): Graph<Int> {
     return graph
 }
 
+val v0 = Vertex(0, 0)
+val v1 = Vertex(1, 1)
+val v2 = Vertex(2, 2)
+val v3 = Vertex(3, 3)
+val v4 = Vertex(4, 4)
+
+val defaultVertices = listOf(v0, v1, v2, v3, v4)
+
+val defaultEdges = setOf(
+    Edge(v0, v1),
+    Edge(v1, v2),
+    Edge(v2, v3),
+    Edge(v3, v4),
+    Edge(v4, v1)
+)
+
 class GraphTest {
     @Nested
-    inner class GetVerticesTest {}
+    inner class GetVerticesTest {
+        inner class `Graph is not empty` {
+            @TestAllGraphTypes
+            fun `non-empty list of vertices should be returned`(graph: Graph<Int>) {
+                setup(graph)
+
+                val actualList = graph.getVertices()
+                val expectedList = defaultVertices
+
+                assertEquals(expectedList, actualList)
+            }
+
+            @TestAllGraphTypes
+            fun `graph should not change`(graph: Graph<Int>) {
+                setup(graph)
+
+                val actualGraph = graph.getVertices() to graph.getEdges().toSet()
+                val expectedGraph = defaultVertices to defaultEdges
+
+                assertEquals(expectedGraph, actualGraph)
+            }
+        }
+
+        inner class `Graph is empty` {
+            @TestAllGraphTypes
+            fun `empty list is should be returned`(graph: Graph<Int>) {
+                val actualList = graph.getVertices()
+                val expectedList: List<Int> = listOf()
+
+                assertEquals(expectedList, actualList)
+            }
+
+            @TestAllGraphTypes
+            fun `graph should not change`(graph: Graph<Int>) {
+                val actualGraph = graph.getVertices() to graph.getEdges().toSet()
+                val expectedGraph = defaultVertices to defaultEdges
+
+                assertEquals(expectedGraph, actualGraph)
+            }
+        }
+    }
 
     @Nested
-    inner class GetEdgesTest {}
+    inner class GetEdgesTest {
+        inner class `Graph is not empty` {
+            @TestAllGraphTypes
+            fun `non-empty list of edges should be returned`(graph: Graph<Int>) {
+                setup(graph)
+
+                val actualSet = graph.getEdges().toSet()
+                val expectedSet = defaultEdges
+
+                assertEquals(expectedSet, actualSet)
+            }
+
+            @TestAllGraphTypes
+            fun `graph should not change`(graph: Graph<Int>) {
+                setup(graph)
+
+                val actualGraph = graph.getVertices() to graph.getEdges().toSet()
+                val expectedGraph = defaultVertices to defaultEdges
+
+                assertEquals(expectedGraph, actualGraph)
+            }
+        }
+
+        inner class `Graph is empty` {
+            @TestAllGraphTypes
+            fun `empty list is should be returned`(graph: Graph<Int>) {
+                val actualSet = graph.getEdges().toSet()
+                val expectedSet = defaultEdges
+
+                assertEquals(expectedSet, actualSet)
+            }
+
+            @TestAllGraphTypes
+            fun `graph should not change`(graph: Graph<Int>) {
+                val actualGraph = graph.getVertices() to graph.getEdges().toSet()
+                val expectedGraph = defaultVertices to defaultEdges
+
+                assertEquals(expectedGraph, actualGraph)
+            }
+        }
+    }
 
     @Nested
     inner class AddVertexTest {}


### PR DESCRIPTION
Add parameterized tests for all basic methods of abstract graph, they are tested on all its inheritors.