### PR TITLE
Change exception messages and use getEdge where possible

### DIFF
--- a/app/src/main/kotlin/model/DirectedGraph.kt
+++ b/app/src/main/kotlin/model/DirectedGraph.kt
@@ -12,7 +12,7 @@ open class DirectedGraph<D> : Graph<D>() {
         if (vertex1.id > vertices.size || vertex2.id > vertices.size)
             throw NoSuchElementException(
                 "One of vertices (${vertex1.id}, ${vertex1.data}) and " +
-                    "(${vertex2.id}, ${vertex2.data}) is not in the vertices array."
+                    "(${vertex2.id}, ${vertex2.data}) isn't in the graph"
             )
 
         val newEdge = Edge(vertex1, vertex2)
@@ -27,7 +27,7 @@ open class DirectedGraph<D> : Graph<D>() {
     override fun removeEdge(edgeToRemove: Edge<D>): Edge<D> {
         if (edgeToRemove !in edges) throw NoSuchElementException(
             "Edge between vertices (${edgeToRemove.vertex1.id}, ${edgeToRemove.vertex1.data}) and " +
-                "(${edgeToRemove.vertex2.id}, ${edgeToRemove.vertex2.data}) is not in the graph"
+                "(${edgeToRemove.vertex2.id}, ${edgeToRemove.vertex2.data}) isn't in the graph"
         )
 
         val vertex1 = edgeToRemove.vertex1

--- a/app/src/main/kotlin/model/UndirectedGraph.kt
+++ b/app/src/main/kotlin/model/UndirectedGraph.kt
@@ -8,12 +8,12 @@ import model.abstractGraph.Vertex
 open class UndirectedGraph<D> : Graph<D>() {
     override fun addEdge(vertex1: Vertex<D>, vertex2: Vertex<D>): Edge<D> {
         if (vertex1 == vertex2)
-            throw IllegalArgumentException("Can't add edge from vertex to itself.")
+            throw IllegalArgumentException("Can't add edge from vertex to itself")
 
         if (vertex1.id > vertices.size || vertex2.id > vertices.size)
             throw NoSuchElementException(
                 "One of vertices (${vertex1.id}, ${vertex1.data}) and " +
-                    "(${vertex2.id}, ${vertex2.data}) is not in the vertices array."
+                    "(${vertex2.id}, ${vertex2.data}) isn't in the graph"
             )
 
         val newEdge = Edge(vertex1, vertex2)
@@ -32,7 +32,7 @@ open class UndirectedGraph<D> : Graph<D>() {
         if (edgeToRemove !in edges)
             throw NoSuchElementException(
                 "Edge between vertices (${edgeToRemove.vertex1.id}, ${edgeToRemove.vertex1.data}) and " +
-                    "(${edgeToRemove.vertex2.id}, ${edgeToRemove.vertex2.data}) is not in the graph"
+                    "(${edgeToRemove.vertex2.id}, ${edgeToRemove.vertex2.data}) isn't in the graph"
             )
 
         val vertex1 = edgeToRemove.vertex1

--- a/app/src/main/kotlin/model/WeightedDirectedGraph.kt
+++ b/app/src/main/kotlin/model/WeightedDirectedGraph.kt
@@ -38,18 +38,17 @@ class WeightedDirectedGraph<D> : DirectedGraph<D>() {
         distanceMap[srcVertex] = 0
 
         while (priorityQueue.isNotEmpty()) {
-            val (vertex, currentDistance) = priorityQueue.poll()
-            if (visited.add(vertex to currentDistance)) {
-                adjacencyMap[vertex]?.forEach { adjacent ->
-                    val currentEdge = getEdge(adjacent, vertex)
-                    currentEdge.let {
-                        var totalDist = currentDistance
-                        totalDist += getWeight(it)
-                        if (totalDist < distanceMap.getValue(adjacent)) {
-                            distanceMap[adjacent] = totalDist
-                            predecessorMap[adjacent] = vertex // Update predecessor
-                            priorityQueue.add(adjacent to totalDist)
-                        }
+            val (currentVertex, currentDistance) = priorityQueue.poll()
+            if (visited.add(currentVertex to currentDistance)) {
+                adjacencyMap[currentVertex]?.forEach { adjacent ->
+                    val currentEdge = getEdge(adjacent, currentVertex)
+
+                    val totalDist = currentDistance + getWeight(currentEdge)
+
+                    if (totalDist < distanceMap.getValue(adjacent)) {
+                        distanceMap[adjacent] = totalDist
+                        predecessorMap[adjacent] = currentVertex // Update predecessor
+                        priorityQueue.add(adjacent to totalDist)
                     }
                 }
             }
@@ -60,14 +59,15 @@ class WeightedDirectedGraph<D> : DirectedGraph<D>() {
         var currentVertex = destVertex
         while (currentVertex != srcVertex) {
             val predecessor = predecessorMap[currentVertex]
+
             if (predecessor == null) {
                 // If no path exists
                 return emptyList()
             }
 
-            path.add(
-                Pair(currentVertex, getEdge(predecessor, currentVertex))
-            )
+            val currentEdge = getEdge(predecessor, currentVertex)
+            path.add(Pair(currentVertex, currentEdge))
+
             currentVertex = predecessor
         }
         return path.reversed()

--- a/app/src/main/kotlin/model/WeightedDirectedGraph.kt
+++ b/app/src/main/kotlin/model/WeightedDirectedGraph.kt
@@ -16,9 +16,7 @@ class WeightedDirectedGraph<D> : DirectedGraph<D>() {
         return newEdge
     }
 
-    /**
-     * In case weight is not passed, set it to default value = 1
-     */
+    // In case weight is not passed, set it to default value = 1
     override fun addEdge(vertex1: Vertex<D>, vertex2: Vertex<D>) = addEdge(vertex1, vertex2, 1)
 
     fun getWeight(edge: Edge<D>): Int {

--- a/app/src/main/kotlin/model/WeightedDirectedGraph.kt
+++ b/app/src/main/kotlin/model/WeightedDirectedGraph.kt
@@ -38,16 +38,16 @@ class WeightedDirectedGraph<D> : DirectedGraph<D>() {
         distanceMap[srcVertex] = 0
 
         while (priorityQueue.isNotEmpty()) {
-            val (node, currentDistance) = priorityQueue.poll()
-            if (visited.add(node to currentDistance)) {
-                adjacencyMap[node]?.forEach { adjacent ->
-                    val currentEdge = edges.find { it.vertex1 == adjacent }
-                    currentEdge?.let {
+            val (vertex, currentDistance) = priorityQueue.poll()
+            if (visited.add(vertex to currentDistance)) {
+                adjacencyMap[vertex]?.forEach { adjacent ->
+                    val currentEdge = getEdge(adjacent, vertex)
+                    currentEdge.let {
                         var totalDist = currentDistance
                         totalDist += getWeight(it)
                         if (totalDist < distanceMap.getValue(adjacent)) {
                             distanceMap[adjacent] = totalDist
-                            predecessorMap[adjacent] = node // Update predecessor
+                            predecessorMap[adjacent] = vertex // Update predecessor
                             priorityQueue.add(adjacent to totalDist)
                         }
                     }

--- a/app/src/main/kotlin/model/WeightedUndirectedGraph.kt
+++ b/app/src/main/kotlin/model/WeightedUndirectedGraph.kt
@@ -39,21 +39,17 @@ class WeightedUndirectedGraph<D> : UndirectedGraph<D>() {
         distanceMap[srcVertex] = 0
 
         while (priorityQueue.isNotEmpty()) {
-            val (node, currentDistance) = priorityQueue.poll()
-            if (visited.add(node to currentDistance)) {
-                adjacencyMap[node]?.forEach { adjacent ->
-                    val currentEdge =
-                        edges.find {
-                            (it.vertex1 == adjacent && it.vertex2 == node) ||
-                                    (it.vertex1 == node && it.vertex2 == adjacent)
-                        }
-                    currentEdge?.let {
+            val (vertex, currentDistance) = priorityQueue.poll()
+            if (visited.add(vertex to currentDistance)) {
+                adjacencyMap[vertex]?.forEach { adjacent ->
+                    val currentEdge = getEdge(adjacent, vertex)
+                    currentEdge.let {
                         var totalDist = currentDistance
                         totalDist += getWeight(it)
 
                         if (totalDist < distanceMap.getValue(adjacent)) {
                             distanceMap[adjacent] = totalDist
-                            predecessorMap[adjacent] = node // Update predecessor
+                            predecessorMap[adjacent] = vertex // Update predecessor
                             priorityQueue.add(adjacent to totalDist)
                         }
                     }
@@ -71,15 +67,10 @@ class WeightedUndirectedGraph<D> : UndirectedGraph<D>() {
                 // If no path exists
                 return emptyList()
             }
-            if (edges.find {
-                    it.vertex1 == predecessor && it.vertex2 == currentVertex ||
-                            it.vertex2 == predecessor && it.vertex1 == currentVertex
-                } == null) {
-                throw NoSuchElementException("Edge is not in the graph, path cannot be reconstructed.")
-            }
-            path.add(
-                Pair(currentVertex, getEdge(predecessor, currentVertex))
-            )
+
+            val currentEdge = getEdge(predecessor, currentVertex)
+            path.add(Pair(currentVertex, currentEdge))
+
             currentVertex = predecessor
         }
         return path.reversed()

--- a/app/src/main/kotlin/model/WeightedUndirectedGraph.kt
+++ b/app/src/main/kotlin/model/WeightedUndirectedGraph.kt
@@ -39,19 +39,17 @@ class WeightedUndirectedGraph<D> : UndirectedGraph<D>() {
         distanceMap[srcVertex] = 0
 
         while (priorityQueue.isNotEmpty()) {
-            val (vertex, currentDistance) = priorityQueue.poll()
-            if (visited.add(vertex to currentDistance)) {
-                adjacencyMap[vertex]?.forEach { adjacent ->
-                    val currentEdge = getEdge(adjacent, vertex)
-                    currentEdge.let {
-                        var totalDist = currentDistance
-                        totalDist += getWeight(it)
+            val (currentVertex, currentDistance) = priorityQueue.poll()
+            if (visited.add(currentVertex to currentDistance)) {
+                adjacencyMap[currentVertex]?.forEach { adjacent ->
+                    val currentEdge = getEdge(adjacent, currentVertex)
 
-                        if (totalDist < distanceMap.getValue(adjacent)) {
-                            distanceMap[adjacent] = totalDist
-                            predecessorMap[adjacent] = vertex // Update predecessor
-                            priorityQueue.add(adjacent to totalDist)
-                        }
+                    val totalDist = currentDistance + getWeight(currentEdge)
+
+                    if (totalDist < distanceMap.getValue(adjacent)) {
+                        distanceMap[adjacent] = totalDist
+                        predecessorMap[adjacent] = currentVertex // Update predecessor
+                        priorityQueue.add(adjacent to totalDist)
                     }
                 }
             }

--- a/app/src/main/kotlin/model/WeightedUndirectedGraph.kt
+++ b/app/src/main/kotlin/model/WeightedUndirectedGraph.kt
@@ -16,9 +16,8 @@ class WeightedUndirectedGraph<D> : UndirectedGraph<D>() {
         return newEdge
     }
 
-    /**
-     * In case weight is not passed, set it to default value = 1
-     */
+
+    // In case weight is not passed, set it to default value = 1
     override fun addEdge(vertex1: Vertex<D>, vertex2: Vertex<D>) = addEdge(vertex1, vertex2, 1)
 
     fun getWeight(edge: Edge<D>): Int {

--- a/app/src/main/kotlin/model/abstractGraph/Graph.kt
+++ b/app/src/main/kotlin/model/abstractGraph/Graph.kt
@@ -60,14 +60,14 @@ abstract class Graph<D> {
 
     fun getNeighbours(vertex: Vertex<D>): ArrayList<Vertex<D>> {
         val neighbours = adjacencyMap[vertex]
-            ?: throw NoSuchElementException("Vertex with id ${vertex.id} is not present in the adjacency map.")
+            ?: throw NoSuchElementException("Vertex (${vertex.id}, ${vertex.data}) isn't in the adjacency map.")
 
         return neighbours
     }
 
     fun getOutgoingEdges(vertex: Vertex<D>): ArrayList<Edge<D>> {
         val outgoingEdges = outgoingEdgesMap[vertex]
-            ?: throw NoSuchElementException("Vertex with id ${vertex.id} is not present in the outgoing edges map.")
+            ?: throw NoSuchElementException("Vertex (${vertex.id}, ${vertex.data}) isn't in the adjacency map.")
 
         return outgoingEdges
     }


### PR DESCRIPTION
Change exception messages so that they say more about the problematic vertices.

Use getEdge method instead of edges.find where possible.

Add empty lines for readability.

TODO: mb move algos from graps.