### PR TITLE
Change types of map values to mutable sets

### DIFF
--- a/app/src/main/kotlin/model/DirectedGraph.kt
+++ b/app/src/main/kotlin/model/DirectedGraph.kt
@@ -15,6 +15,9 @@ open class DirectedGraph<D> : Graph<D>() {
                     "(${vertex2.id}, ${vertex2.data}) isn't in the graph"
             )
 
+        // Don't do anything if the edge is already in the graph
+        if (vertex2 in getNeighbours(vertex1)) return getEdge(vertex1, vertex2)
+
         val newEdge = Edge(vertex1, vertex2)
         edges.add(newEdge)
 
@@ -88,10 +91,10 @@ open class DirectedGraph<D> : Graph<D>() {
     }
 
     private fun reverseGraph() {
-        val reversedAdjacencyMap = mutableMapOf<Vertex<D>, ArrayList<Vertex<D>>>()
+        val reversedAdjacencyMap = mutableMapOf<Vertex<D>, MutableSet<Vertex<D>>>()
         for (vertex in vertices) {
             adjacencyMap[vertex]?.forEach { vertex2 ->
-                reversedAdjacencyMap[vertex2] = reversedAdjacencyMap[vertex2] ?: ArrayList()
+                reversedAdjacencyMap[vertex2] = reversedAdjacencyMap[vertex2] ?: mutableSetOf()
                 reversedAdjacencyMap[vertex2]?.add(vertex)
             }
         }

--- a/app/src/main/kotlin/model/UndirectedGraph.kt
+++ b/app/src/main/kotlin/model/UndirectedGraph.kt
@@ -16,6 +16,9 @@ open class UndirectedGraph<D> : Graph<D>() {
                     "(${vertex2.id}, ${vertex2.data}) isn't in the graph"
             )
 
+        // Don't do anything if the edge is already in the graph
+        if (vertex2 in getNeighbours(vertex1)) return getEdge(vertex1, vertex2)
+
         val newEdge = Edge(vertex1, vertex2)
         edges.add(newEdge)
 

--- a/app/src/main/kotlin/model/abstractGraph/Graph.kt
+++ b/app/src/main/kotlin/model/abstractGraph/Graph.kt
@@ -4,16 +4,16 @@ abstract class Graph<D> {
     protected val vertices: ArrayList<Vertex<D>> = arrayListOf()
     protected val edges: MutableSet<Edge<D>> = mutableSetOf()
 
-    protected val adjacencyMap: MutableMap<Vertex<D>, ArrayList<Vertex<D>>> = mutableMapOf()
-    protected val outgoingEdgesMap: MutableMap<Vertex<D>, ArrayList<Edge<D>>> = mutableMapOf()
+    protected val adjacencyMap: MutableMap<Vertex<D>, MutableSet<Vertex<D>>> = mutableMapOf()
+    protected val outgoingEdgesMap: MutableMap<Vertex<D>, MutableSet<Edge<D>>> = mutableMapOf()
 
     private var nextId = 0
 
     fun addVertex(data: D): Vertex<D> {
         val newVertex = Vertex(nextId++, data)
 
-        outgoingEdgesMap[newVertex] = ArrayList()
-        adjacencyMap[newVertex] = ArrayList()
+        outgoingEdgesMap[newVertex] = mutableSetOf()
+        adjacencyMap[newVertex] = mutableSetOf()
 
         vertices.add(newVertex)
 
@@ -58,18 +58,18 @@ abstract class Graph<D> {
 
     fun getVertices() = vertices.toList()
 
-    fun getNeighbours(vertex: Vertex<D>): ArrayList<Vertex<D>> {
+    fun getNeighbours(vertex: Vertex<D>): List<Vertex<D>> {
         val neighbours = adjacencyMap[vertex]
             ?: throw NoSuchElementException("Vertex (${vertex.id}, ${vertex.data}) isn't in the adjacency map.")
 
-        return neighbours
+        return neighbours.toList()
     }
 
-    fun getOutgoingEdges(vertex: Vertex<D>): ArrayList<Edge<D>> {
+    fun getOutgoingEdges(vertex: Vertex<D>): List<Edge<D>> {
         val outgoingEdges = outgoingEdgesMap[vertex]
             ?: throw NoSuchElementException("Vertex (${vertex.id}, ${vertex.data}) isn't in the adjacency map.")
 
-        return outgoingEdges
+        return outgoingEdges.toList()
     }
 
     abstract fun getEdge(vertex1: Vertex<D>, vertex2: Vertex<D>): Edge<D>


### PR DESCRIPTION
Types of adjacency map and outgoing edges map values were array lists, which enabled to store the same vertices and edges in map values. It caused problems if already existing edge is added, then map values of the added edge's vertex1 will have duplicates.

Change adjacency map and outgoing edges map values to mutable sets.