### PR TITLE
Add tests for graph implementations' basic methods

### DIFF
--- a/app/src/main/kotlin/model/DirectedGraph.kt
+++ b/app/src/main/kotlin/model/DirectedGraph.kt
@@ -9,9 +9,9 @@ open class DirectedGraph<D> : Graph<D>() {
         if (vertex1 == vertex2)
             throw IllegalArgumentException("Can't add edge from vertex to itself.")
 
-        if (vertex1.id > vertices.size || vertex2.id > vertices.size)
-            throw NoSuchElementException(
-                "One of vertices (${vertex1.id}, ${vertex1.data}) and " +
+        if (vertex1 !in vertices || vertex2 !in vertices)
+            throw IllegalArgumentException(
+                "One of the vertices (${vertex1.id}, ${vertex1.data}) and " +
                     "(${vertex2.id}, ${vertex2.data}) isn't in the graph"
             )
 

--- a/app/src/main/kotlin/model/UndirectedGraph.kt
+++ b/app/src/main/kotlin/model/UndirectedGraph.kt
@@ -10,8 +10,8 @@ open class UndirectedGraph<D> : Graph<D>() {
         if (vertex1 == vertex2)
             throw IllegalArgumentException("Can't add edge from vertex to itself")
 
-        if (vertex1.id > vertices.size || vertex2.id > vertices.size)
-            throw NoSuchElementException(
+        if (vertex1 !in vertices || vertex2 !in vertices)
+            throw IllegalArgumentException(
                 "One of vertices (${vertex1.id}, ${vertex1.data}) and " +
                     "(${vertex2.id}, ${vertex2.data}) isn't in the graph"
             )

--- a/app/src/main/kotlin/model/WeightedDirectedGraph.kt
+++ b/app/src/main/kotlin/model/WeightedDirectedGraph.kt
@@ -22,7 +22,7 @@ class WeightedDirectedGraph<D> : DirectedGraph<D>() {
     fun getWeight(edge: Edge<D>): Int {
         val weight = weightMap[edge]
             ?: throw NoSuchElementException(
-                "No weight found for edge between vertices (${edge.vertex1.id}, ${edge.vertex1.data})" +
+                "No weight found for edge between vertices (${edge.vertex1.id}, ${edge.vertex1.data}) " +
                     "and (${edge.vertex2.id}, ${edge.vertex2.data})"
             )
 

--- a/app/src/main/kotlin/model/WeightedUndirectedGraph.kt
+++ b/app/src/main/kotlin/model/WeightedUndirectedGraph.kt
@@ -23,7 +23,7 @@ class WeightedUndirectedGraph<D> : UndirectedGraph<D>() {
     fun getWeight(edge: Edge<D>): Int {
         val weight = weightMap[edge]
             ?: throw NoSuchElementException(
-                "No weight found for edge between vertices (${edge.vertex1.id}, ${edge.vertex1.data})" +
+                "No weight found for edge between vertices (${edge.vertex1.id}, ${edge.vertex1.data}) " +
                     "and (${edge.vertex2.id}, ${edge.vertex2.data})"
             )
 

--- a/app/src/main/kotlin/model/abstractGraph/Graph.kt
+++ b/app/src/main/kotlin/model/abstractGraph/Graph.kt
@@ -67,7 +67,7 @@ abstract class Graph<D> {
 
     fun getOutgoingEdges(vertex: Vertex<D>): List<Edge<D>> {
         val outgoingEdges = outgoingEdgesMap[vertex]
-            ?: throw NoSuchElementException("Vertex (${vertex.id}, ${vertex.data}) isn't in the adjacency map.")
+            ?: throw NoSuchElementException("Vertex (${vertex.id}, ${vertex.data}) isn't in the outgoing edges map.")
 
         return outgoingEdges.toList()
     }

--- a/app/src/test/kotlin/model/DirectedGraphTest.kt
+++ b/app/src/test/kotlin/model/DirectedGraphTest.kt
@@ -1,10 +1,13 @@
 package model
 
+import model.abstractGraph.Edge
 import model.abstractGraph.Vertex
 import org.junit.jupiter.api.Nested
 import util.annotations.TestAllDirectedGraphs
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
+import util.emptyEdgesSet
+import util.emptyVerticesList
 import util.setup
 
 class DirectedGraphTest {
@@ -293,7 +296,88 @@ class DirectedGraphTest {
     }
 
     @Nested
-    inner class RemoveEdgeTest {}
+    inner class RemoveEdgeTest {
+        @Nested
+        inner class `Edge is in the graph` {
+            @TestAllDirectedGraphs
+            fun `removed edge should be returned`(graph: DirectedGraph<Int>) {
+                val graphStructure = setup(graph)
+                val defaultVerticesList = graphStructure.first
+
+                val v1 = defaultVerticesList[1]
+                val v3 = defaultVerticesList[3]
+
+                val edgeToRemove = graph.getEdge(v3, v1)
+
+                val actualValue = graph.removeEdge(edgeToRemove)
+                val expectedValue = edgeToRemove
+
+                assertEquals(expectedValue, actualValue)
+            }
+
+            @TestAllDirectedGraphs
+            fun `edge should be removed from graph`(graph: DirectedGraph<Int>) {
+                val graphStructure = setup(graph)
+                val defaultVerticesList = graphStructure.first
+                val defaultEdgesSet = graphStructure.second
+
+                val v1 = defaultVerticesList[1]
+                val v4 = defaultVerticesList[4]
+
+                val edgeToRemove = graph.getEdge(v4, v1)
+                graph.removeEdge(edgeToRemove)
+
+                val actualEdges = graph.getEdges().toSet()
+                val expectedEdges = defaultEdgesSet - edgeToRemove
+
+                assertEquals(expectedEdges, actualEdges)
+            }
+
+            @TestAllDirectedGraphs
+            fun `second vertex should be removed from first's adjacency map`(graph: DirectedGraph<Int>) {
+                val graphStructure = setup(graph)
+                val defaultVerticesList = graphStructure.first
+
+                val v1 = defaultVerticesList[1]
+                val v2 = defaultVerticesList[2]
+
+                val edgeToRemove = graph.getEdge(v1, v2)
+                graph.removeEdge(edgeToRemove)
+
+                val actualVertices = graph.getNeighbours(v1).toSet()
+                val expectedVertices = emptyVerticesList.toSet()
+
+                assertEquals(expectedVertices, actualVertices)
+            }
+
+            @TestAllDirectedGraphs
+            fun `edge should be removed from first vertex's outgoing edges map`(graph: DirectedGraph<Int>) {
+                val graphStructure = setup(graph)
+                val defaultVerticesList = graphStructure.first
+
+                val v2 = defaultVerticesList[2]
+                val v3 = defaultVerticesList[3]
+
+                val edgeToRemove = graph.getEdge(v2, v3)
+                graph.removeEdge(edgeToRemove)
+
+                val actualEdges = graph.getOutgoingEdges(v2).toSet()
+                val expectedEdges = emptyEdgesSet
+
+                assertEquals(expectedEdges, actualEdges)
+            }
+        }
+
+        @Nested
+        inner class `Edge isn't in the graph` {
+            @TestAllDirectedGraphs
+            fun `exception should be thrown`(graph: DirectedGraph<Int>) {
+                assertThrows(NoSuchElementException::class.java) {
+                    graph.removeEdge(Edge(Vertex(0,0), Vertex(1, 1)))
+                }
+            }
+        }
+    }
 
     @Nested
     inner class FindSCCTest {}

--- a/app/src/test/kotlin/model/DirectedGraphTest.kt
+++ b/app/src/test/kotlin/model/DirectedGraphTest.kt
@@ -23,6 +23,15 @@ class WeightedAndUnweightedDirectedGraphsProvider : ArgumentsProvider {
 
 class DirectedGraphTest {
     @Nested
+    inner class GetEdgeTest {}
+
+    @Nested
+    inner class GetNeighboursTest {}
+
+    @Nested
+    inner class GetOutgoingEdgesTest {}
+
+    @Nested
     inner class AddEdgeTest {}
 
     @Nested

--- a/app/src/test/kotlin/model/DirectedGraphTest.kt
+++ b/app/src/test/kotlin/model/DirectedGraphTest.kt
@@ -205,7 +205,7 @@ class DirectedGraphTest {
                 }
 
                 @TestAllDirectedGraphs
-                fun `one vertex has to be added to the other's adjacency map`(graph: DirectedGraph<Int>) {
+                fun `one vertex has to be added to the other's adjacency map value`(graph: DirectedGraph<Int>) {
                     val graphStructure = setup(graph)
                     val defaultVerticesList = graphStructure.first
 
@@ -224,7 +224,7 @@ class DirectedGraphTest {
                 }
 
                 @TestAllDirectedGraphs
-                fun `edge has to be added to first vertex's outgoing edges map`(graph: DirectedGraph<Int>) {
+                fun `edge has to be added to first vertex's outgoing edges map value`(graph: DirectedGraph<Int>) {
                     val graphStructure = setup(graph)
                     val defaultVerticesList = graphStructure.first
 
@@ -377,7 +377,7 @@ class DirectedGraphTest {
             }
 
             @TestAllDirectedGraphs
-            fun `second vertex should be removed from first's adjacency map`(graph: DirectedGraph<Int>) {
+            fun `second vertex should be removed from first's adjacency map value`(graph: DirectedGraph<Int>) {
                 val graphStructure = setup(graph)
                 val defaultVerticesList = graphStructure.first
 
@@ -394,7 +394,7 @@ class DirectedGraphTest {
             }
 
             @TestAllDirectedGraphs
-            fun `edge should be removed from first vertex's outgoing edges map`(graph: DirectedGraph<Int>) {
+            fun `edge should be removed from first vertex's outgoing edges map value`(graph: DirectedGraph<Int>) {
                 val graphStructure = setup(graph)
                 val defaultVerticesList = graphStructure.first
 
@@ -427,7 +427,7 @@ class DirectedGraphTest {
             }
 
             @TestAllDirectedGraphs
-            fun `exception should be thrown`(graph: DirectedGraph<Int>) {
+            fun `non-existing edge should throw an exception`(graph: DirectedGraph<Int>) {
                 assertThrows(NoSuchElementException::class.java) {
                     graph.removeEdge(Edge(Vertex(0,0), Vertex(1, 1)))
                 }

--- a/app/src/test/kotlin/model/DirectedGraphTest.kt
+++ b/app/src/test/kotlin/model/DirectedGraphTest.kt
@@ -1,25 +1,8 @@
 package model
 
 import org.junit.jupiter.api.Nested
-import org.junit.jupiter.api.extension.ExtensionContext
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.Arguments
-import org.junit.jupiter.params.provider.ArgumentsProvider
-import org.junit.jupiter.params.provider.ArgumentsSource
-import java.util.stream.Stream
-
-@ParameterizedTest(name = "{0}")
-@ArgumentsSource(WeightedAndUnweightedDirectedGraphsProvider::class)
-@Target(AnnotationTarget.FUNCTION)
-@Retention(AnnotationRetention.RUNTIME)
-private annotation class TestBothDirectedGraphs
-
-class WeightedAndUnweightedDirectedGraphsProvider : ArgumentsProvider {
-    override fun provideArguments(context: ExtensionContext?): Stream<Arguments> = Stream.of(
-        Arguments.of(DirectedGraph<Int>()),
-        Arguments.of(WeightedDirectedGraph<Int>())
-    )
-}
+import util.annotations.TestAllDirectedGraphs
+import util.setup
 
 class DirectedGraphTest {
     @Nested

--- a/app/src/test/kotlin/model/DirectedGraphTest.kt
+++ b/app/src/test/kotlin/model/DirectedGraphTest.kt
@@ -1,12 +1,72 @@
 package model
 
+import model.abstractGraph.Vertex
 import org.junit.jupiter.api.Nested
 import util.annotations.TestAllDirectedGraphs
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.assertThrows
 import util.setup
 
 class DirectedGraphTest {
     @Nested
-    inner class GetEdgeTest {}
+    inner class GetEdgeTest {
+        @Nested
+        inner class `Edge is in the graph` {
+            @TestAllDirectedGraphs
+            fun `edge should be returned`(graph: DirectedGraph<Int>) {
+                val graphStructure = setup(graph)
+                val defaultVerticesList = graphStructure.first
+
+                val v0 = defaultVerticesList[0]
+                val v2 = defaultVerticesList[2]
+
+                val expectedValue = graph.addEdge(v0, v2)
+                val actualValue = graph.getEdge(v0, v2)
+
+                assertEquals(expectedValue, actualValue)
+            }
+
+            @TestAllDirectedGraphs
+            fun `graph shouldn't change`(graph: DirectedGraph<Int>) {
+                val graphStructure = setup(graph)
+                val defaultVerticesList = graphStructure.first
+
+                val v2 = defaultVerticesList[2]
+                val v3 = defaultVerticesList[3]
+
+                graph.getEdge(v2, v3)
+
+                val actualGraph = graph.getVertices() to graph.getEdges().toSet()
+                val expectedGraph = graphStructure
+
+                assertEquals(expectedGraph, actualGraph)
+            }
+        }
+
+        @Nested
+        inner class `Edge isn't in the graph` {
+            @TestAllDirectedGraphs
+            fun `order of arguments should matter`(graph: DirectedGraph<Int>) {
+                val graphStructure = setup(graph)
+                val defaultVerticesList = graphStructure.first
+
+                val v0 = defaultVerticesList[0]
+                val v1 = defaultVerticesList[1]
+
+                assertThrows(NoSuchElementException::class.java) {
+                    graph.getEdge(v1, v0)
+                }
+            }
+
+            @TestAllDirectedGraphs
+            fun `getting non-existent edge should throw an exception`(graph: DirectedGraph<Int>) {
+                assertThrows(NoSuchElementException::class.java) {
+                    graph.getEdge(Vertex(2, 12), Vertex(85, 6))
+                }
+            }
+        }
+    }
 
     @Nested
     inner class GetNeighboursTest {}

--- a/app/src/test/kotlin/model/DirectedGraphTest.kt
+++ b/app/src/test/kotlin/model/DirectedGraphTest.kt
@@ -21,8 +21,10 @@ class DirectedGraphTest {
                 val v0 = defaultVerticesList[0]
                 val v2 = defaultVerticesList[2]
 
-                val expectedValue = graph.addEdge(v0, v2)
-                val actualValue = graph.getEdge(v0, v2)
+                val newEdge = graph.addEdge(v0, v2)
+
+                val actualValue = newEdge
+                val expectedValue = graph.getEdge(v0, v2)
 
                 assertEquals(expectedValue, actualValue)
             }
@@ -60,7 +62,7 @@ class DirectedGraphTest {
             }
 
             @TestAllDirectedGraphs
-            fun `getting non-existent edge should throw an exception`(graph: DirectedGraph<Int>) {
+            fun `trying to get non-existent edge should throw an exception`(graph: DirectedGraph<Int>) {
                 assertThrows(NoSuchElementException::class.java) {
                     graph.getEdge(Vertex(2, 12), Vertex(85, 6))
                 }
@@ -69,10 +71,100 @@ class DirectedGraphTest {
     }
 
     @Nested
-    inner class GetNeighboursTest {}
+    inner class GetNeighboursTest {
+        @Nested
+        inner class `Vertex is in the graph` {
+            @TestAllDirectedGraphs
+            fun `neighbours should be returned`(graph: DirectedGraph<Int>) {
+                val graphStructure = setup(graph)
+                val defaultVerticesList = graphStructure.first
+
+                val v0 = defaultVerticesList[0]
+                val v1 = defaultVerticesList[1]
+                val v2 = defaultVerticesList[2]
+                val v3 = defaultVerticesList[3]
+                val v4 = defaultVerticesList[4]
+
+                val actualValue = graph.getNeighbours(v3).toSet()
+                val expectedValue = setOf(v4, v1)
+
+                assertEquals(expectedValue, actualValue)
+            }
+
+            @TestAllDirectedGraphs
+            fun `graph shouldn't change`(graph: DirectedGraph<Int>) {
+                val graphStructure = setup(graph)
+                val defaultVerticesList = graphStructure.first
+
+                val v0 = defaultVerticesList[0]
+
+                graph.getNeighbours(v0)
+
+                val actualGraph = graph.getVertices() to graph.getEdges().toSet()
+                val expectedGraph = graphStructure
+
+                assertEquals(expectedGraph, actualGraph)
+            }
+        }
+
+        @Nested
+        inner class `Vertex isn't in the graph` {
+            @TestAllDirectedGraphs
+            fun `exception should be thrown`(graph: DirectedGraph<Int>) {
+                assertThrows(NoSuchElementException::class.java) {
+                    graph.getNeighbours(Vertex(2201, 2006))
+                }
+            }
+        }
+    }
 
     @Nested
-    inner class GetOutgoingEdgesTest {}
+    inner class GetOutgoingEdgesTest {
+        @Nested
+        inner class `Vertex is in the graph` {
+            @TestAllDirectedGraphs
+            fun `outgoing edges should be returned`(graph: DirectedGraph<Int>) {
+                val graphStructure = setup(graph)
+                val defaultVerticesList = graphStructure.first
+
+                val v0 = defaultVerticesList[0]
+                val v1 = defaultVerticesList[1]
+                val v2 = defaultVerticesList[2]
+                val v3 = defaultVerticesList[3]
+                val v4 = defaultVerticesList[4]
+
+                val actualValue = graph.getOutgoingEdges(v3).toSet()
+                val expectedValue = setOf(graph.getEdge(v3, v4), graph.getEdge(v3, v1))
+
+                assertEquals(expectedValue, actualValue)
+            }
+
+            @TestAllDirectedGraphs
+            fun `graph shouldn't change`(graph: DirectedGraph<Int>) {
+                val graphStructure = setup(graph)
+                val defaultVerticesList = graphStructure.first
+
+                val v4 = defaultVerticesList[4]
+
+                graph.getOutgoingEdges(v4)
+
+                val actualGraph = graph.getVertices() to graph.getEdges().toSet()
+                val expectedGraph = graphStructure
+
+                assertEquals(expectedGraph, actualGraph)
+            }
+        }
+
+        @Nested
+        inner class `Vertex isn't in the graph` {
+            @TestAllDirectedGraphs
+            fun `exception should be thrown`(graph: DirectedGraph<Int>) {
+                assertThrows(NoSuchElementException::class.java) {
+                    graph.getOutgoingEdges(Vertex(2611, 2005))
+                }
+            }
+        }
+    }
 
     @Nested
     inner class AddEdgeTest {}

--- a/app/src/test/kotlin/model/DirectedGraphTest.kt
+++ b/app/src/test/kotlin/model/DirectedGraphTest.kt
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Nested
 import util.annotations.TestAllDirectedGraphs
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
-import org.junit.jupiter.api.assertThrows
 import util.setup
 
 class DirectedGraphTest {
@@ -167,7 +166,131 @@ class DirectedGraphTest {
     }
 
     @Nested
-    inner class AddEdgeTest {}
+    inner class AddEdgeTest {
+        @Nested
+        inner class `Two vertices are in the graph` {
+            @Nested
+            inner class `Vertices are different` {
+                @TestAllDirectedGraphs
+                fun `Added edge should be returned`(graph: DirectedGraph<Int>) {
+                    val graphStructure = setup(graph)
+                    val defaultVerticesList = graphStructure.first
+
+                    val v0 = defaultVerticesList[0]
+                    val v4 = defaultVerticesList[4]
+
+                    val actualValue = graph.addEdge(v0, v4)
+                    val expectedValue = graph.getEdge(v0, v4)
+
+                    assertEquals(expectedValue, actualValue)
+                }
+
+                @TestAllDirectedGraphs
+                fun `Edge should be added to graph`(graph: DirectedGraph<Int>) {
+                    val graphStructure = setup(graph)
+                    val defaultVerticesList = graphStructure.first
+                    val defaultEdgesSet = graphStructure.second
+
+                    val v0 = defaultVerticesList[0]
+                    val v4 = defaultVerticesList[4]
+
+                    val newEdge = graph.addEdge(v4, v0)
+
+                    val actualEdges = graph.getEdges().toSet()
+                    val expectedEdges = defaultEdgesSet + newEdge
+
+                    assertEquals(expectedEdges, actualEdges)
+                }
+
+                @TestAllDirectedGraphs
+                fun `one vertex has to be added to the other's adjacency map`(graph: DirectedGraph<Int>) {
+                    val graphStructure = setup(graph)
+                    val defaultVerticesList = graphStructure.first
+
+                    val v0 = defaultVerticesList[0]
+                    val v1 = defaultVerticesList[1]
+                    val v2 = defaultVerticesList[2]
+                    val v3 = defaultVerticesList[3]
+                    val v4 = defaultVerticesList[4]
+
+                    graph.addEdge(v0, v2)
+
+                    val actualVertices = graph.getNeighbours(v0).toSet()
+                    val expectedVertices = setOf(v1, v2)
+
+                    assertEquals(expectedVertices, actualVertices)
+                }
+
+                @TestAllDirectedGraphs
+                fun `edge has to be added to first vertex's outgoing edges map`(graph: DirectedGraph<Int>) {
+                    val graphStructure = setup(graph)
+                    val defaultVerticesList = graphStructure.first
+
+                    val v0 = defaultVerticesList[0]
+                    val v1 = defaultVerticesList[1]
+                    val v2 = defaultVerticesList[2]
+                    val v3 = defaultVerticesList[3]
+                    val v4 = defaultVerticesList[4]
+
+                    graph.addEdge(v3, v0)
+
+                    val actualEdges = graph.getOutgoingEdges(v3).toSet()
+                    val expectedEdges = setOf(graph.getEdge(v3, v4), graph.getEdge(v3, v1), graph.getEdge(v3, v0))
+
+                    assertEquals(expectedEdges, actualEdges)
+                }
+            }
+
+            @Nested
+            inner class `Vertices are the same` {
+                @TestAllDirectedGraphs
+                fun `exception should be thrown`(graph: DirectedGraph<Int>) {
+                    val graphStructure = setup(graph)
+                    val defaultVerticesList = graphStructure.first
+
+                    val v2 = defaultVerticesList[2]
+
+                    assertThrows(IllegalArgumentException::class.java) {
+                        graph.addEdge(v2, v2)
+                    }
+                }
+            }
+        }
+
+        @Nested
+        inner class `One of the vertices isn't in the graph` {
+            @TestAllDirectedGraphs
+            fun `first vertex isn't in the graph`(graph: DirectedGraph<Int>) {
+                val graphStructure = setup(graph)
+                val defaultVerticesList = graphStructure.first
+
+                val v0 = defaultVerticesList[0]
+
+                assertThrows(IllegalArgumentException::class.java) {
+                    graph.addEdge(Vertex(2210, 2005), v0)
+                }
+            }
+
+            @TestAllDirectedGraphs
+            fun `second vertex isn't in the graph`(graph: DirectedGraph<Int>) {
+                val graphStructure = setup(graph)
+                val defaultVerticesList = graphStructure.first
+
+                val v0 = defaultVerticesList[0]
+
+                assertThrows(IllegalArgumentException::class.java) {
+                    graph.addEdge(v0, Vertex(2510, 1917))
+                }
+            }
+
+            @TestAllDirectedGraphs
+            fun `both vertices aren't in the graph`(graph: DirectedGraph<Int>) {
+                assertThrows(IllegalArgumentException::class.java) {
+                    graph.addEdge(Vertex(3010, 1978), Vertex(1002, 1982))
+                }
+            }
+        }
+    }
 
     @Nested
     inner class RemoveEdgeTest {}

--- a/app/src/test/kotlin/model/DirectedGraphTest.kt
+++ b/app/src/test/kotlin/model/DirectedGraphTest.kt
@@ -1,6 +1,25 @@
 package model
 
 import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.ArgumentsProvider
+import org.junit.jupiter.params.provider.ArgumentsSource
+import java.util.stream.Stream
+
+@ParameterizedTest(name = "{0}")
+@ArgumentsSource(WeightedAndUnweightedDirectedGraphsProvider::class)
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+private annotation class TestBothDirectedGraphs
+
+class WeightedAndUnweightedDirectedGraphsProvider : ArgumentsProvider {
+    override fun provideArguments(context: ExtensionContext?): Stream<Arguments> = Stream.of(
+        Arguments.of(DirectedGraph<Int>()),
+        Arguments.of(WeightedDirectedGraph<Int>())
+    )
+}
 
 class DirectedGraphTest {
     @Nested

--- a/app/src/test/kotlin/model/DirectedGraphTest.kt
+++ b/app/src/test/kotlin/model/DirectedGraphTest.kt
@@ -2,10 +2,9 @@ package model
 
 import model.abstractGraph.Edge
 import model.abstractGraph.Vertex
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Nested
 import util.annotations.TestAllDirectedGraphs
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertThrows
 import util.emptyEdgesSet
 import util.emptyVerticesList
 import util.setup
@@ -242,6 +241,50 @@ class DirectedGraphTest {
 
                     assertEquals(expectedEdges, actualEdges)
                 }
+
+                @TestAllDirectedGraphs
+                fun `adding already existing edge shouldn't change anything`(graph: DirectedGraph<Int>) {
+                    val graphStructure = setup(graph)
+                    val defaultVerticesList = graphStructure.first
+
+                    val v1 = defaultVerticesList[1]
+                    val v4 = defaultVerticesList[4]
+
+                    val expectedNeighbours = graph.getNeighbours(v4).toSet()
+                    val expectedOutgoingEdges = graph.getOutgoingEdges(v4).toSet()
+
+                    graph.addEdge(v4, v1)
+
+                    val actualNeighbours = graph.getNeighbours(v4).toSet()
+                    val actualOutgoingEdges = graph.getOutgoingEdges(v4).toSet()
+
+                    val expectedGraph = graphStructure
+                    val actualGraph = graph.getVertices() to graph.getEdges().toSet()
+
+                    assertEquals(expectedGraph, actualGraph)
+                    assertEquals(expectedNeighbours, actualNeighbours)
+                    assertEquals(expectedOutgoingEdges, actualOutgoingEdges)
+                }
+
+                @TestAllDirectedGraphs
+                fun `second vertex's map values shouldn't change`(graph: DirectedGraph<Int>) {
+                    val graphStructure = setup(graph)
+                    val defaultVerticesList = graphStructure.first
+
+                    val v0 = defaultVerticesList[0]
+                    val v3 = defaultVerticesList[3]
+
+                    val expectedNeighbours = graph.getNeighbours(v0).toSet()
+                    val expectedOutgoingEdges = graph.getOutgoingEdges(v0).toSet()
+
+                    graph.addEdge(v3, v0)
+
+                    val actualNeighbours = graph.getNeighbours(v0).toSet()
+                    val actualOutgoingEdges = graph.getOutgoingEdges(v0).toSet()
+
+                    assertEquals(expectedNeighbours, actualNeighbours)
+                    assertEquals(expectedOutgoingEdges, actualOutgoingEdges)
+                }
             }
 
             @Nested
@@ -370,6 +413,19 @@ class DirectedGraphTest {
 
         @Nested
         inner class `Edge isn't in the graph` {
+            @TestAllDirectedGraphs
+            fun `wrong order of the arguments should throw an exception`(graph: DirectedGraph<Int>) {
+                val graphStructure = setup(graph)
+                val defaultVerticesList = graphStructure.first
+
+                val v3 = defaultVerticesList[3]
+                val v4 = defaultVerticesList[4]
+
+                assertThrows(NoSuchElementException::class.java) {
+                    graph.removeEdge(graph.getEdge(v4, v3))
+                }
+            }
+
             @TestAllDirectedGraphs
             fun `exception should be thrown`(graph: DirectedGraph<Int>) {
                 assertThrows(NoSuchElementException::class.java) {

--- a/app/src/test/kotlin/model/UndirectedGraphTest.kt
+++ b/app/src/test/kotlin/model/UndirectedGraphTest.kt
@@ -1,27 +1,545 @@
 package model
 
 import model.abstractGraph.Edge
+import model.abstractGraph.Vertex
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Nested
 import util.annotations.TestAllUndirectedGraphs
+import util.emptyEdgesSet
+import util.emptyVerticesList
 import util.setup
 
 class UndirectedGraphTest {
     @Nested
-    inner class GetEdgeTest {}
+    inner class GetEdgeTest {
+        @Nested
+        inner class `Edge is in the graph` {
+            @TestAllUndirectedGraphs
+            fun `edge should be returned`(graph: UndirectedGraph<Int>) {
+                val graphStructure = setup(graph)
+                val defaultVerticesList = graphStructure.first
+
+                val v0 = defaultVerticesList[0]
+                val v2 = defaultVerticesList[2]
+
+                val newEdge = graph.addEdge(v0, v2)
+
+                val actualValue = newEdge
+                val expectedValue = graph.getEdge(v0, v2)
+
+                assertEquals(expectedValue, actualValue)
+            }
+
+            @TestAllUndirectedGraphs
+            fun `order of the arguments shouldn't matter`(graph: UndirectedGraph<Int>) {
+                val graphStructure = setup(graph)
+                val defaultVerticesList = graphStructure.first
+
+                val v0 = defaultVerticesList[0]
+                val v1 = defaultVerticesList[1]
+
+                assertEquals(graph.getEdge(v0, v1), graph.getEdge(v1, v0))
+            }
+
+            @TestAllUndirectedGraphs
+            fun `graph shouldn't change`(graph: UndirectedGraph<Int>) {
+                val graphStructure = setup(graph)
+                val defaultVerticesList = graphStructure.first
+
+                val v2 = defaultVerticesList[2]
+                val v3 = defaultVerticesList[3]
+
+                graph.getEdge(v2, v3)
+
+                val actualGraph = graph.getVertices() to graph.getEdges().toSet()
+                val expectedGraph = graphStructure
+
+                assertEquals(expectedGraph, actualGraph)
+            }
+        }
+
+        @Nested
+        inner class `Edge isn't in the graph` {
+            @TestAllUndirectedGraphs
+            fun `trying to get non-existent edge should throw an exception`(graph: UndirectedGraph<Int>) {
+                assertThrows(NoSuchElementException::class.java) {
+                    graph.getEdge(Vertex(2, 12), Vertex(85, 6))
+                }
+            }
+        }
+    }
 
     @Nested
-    inner class GetNeighboursTest {}
+    inner class GetNeighboursTest {
+        @Nested
+        inner class `Vertex is in the graph` {
+            @TestAllUndirectedGraphs
+            fun `neighbours should be returned`(graph: UndirectedGraph<Int>) {
+                val graphStructure = setup(graph)
+                val defaultVerticesList = graphStructure.first
+
+                val v0 = defaultVerticesList[0]
+                val v1 = defaultVerticesList[1]
+                val v2 = defaultVerticesList[2]
+                val v3 = defaultVerticesList[3]
+                val v4 = defaultVerticesList[4]
+
+                val actualValue = graph.getNeighbours(v3).toSet()
+                val expectedValue = setOf(v1, v2, v4)
+
+                assertEquals(expectedValue, actualValue)
+            }
+
+            @TestAllUndirectedGraphs
+            fun `graph shouldn't change`(graph: UndirectedGraph<Int>) {
+                val graphStructure = setup(graph)
+                val defaultVerticesList = graphStructure.first
+
+                val v0 = defaultVerticesList[0]
+
+                graph.getNeighbours(v0)
+
+                val actualGraph = graph.getVertices() to graph.getEdges().toSet()
+                val expectedGraph = graphStructure
+
+                assertEquals(expectedGraph, actualGraph)
+            }
+        }
+
+        @Nested
+        inner class `Vertex isn't in the graph` {
+            @TestAllUndirectedGraphs
+            fun `exception should be thrown`(graph: UndirectedGraph<Int>) {
+                assertThrows(NoSuchElementException::class.java) {
+                    graph.getNeighbours(Vertex(2201, 2006))
+                }
+            }
+        }
+    }
 
     @Nested
-    inner class GetOutgoingEdgesTest {}
+    inner class GetOutgoingEdgesTest {
+        @Nested
+        inner class `Vertex is in the graph` {
+            @TestAllUndirectedGraphs
+            fun `outgoing edges should be returned`(graph: UndirectedGraph<Int>) {
+                val graphStructure = setup(graph)
+                val defaultVerticesList = graphStructure.first
+
+                val v0 = defaultVerticesList[0]
+                val v1 = defaultVerticesList[1]
+                val v2 = defaultVerticesList[2]
+                val v3 = defaultVerticesList[3]
+                val v4 = defaultVerticesList[4]
+
+                val actualValue = graph.getOutgoingEdges(v3).toSet()
+                val expectedValue = setOf(
+                    graph.getEdge(v3, v4),
+                    graph.getEdge(v3, v1),
+                    graph.getEdge(v3, v2)
+                )
+
+                assertEquals(expectedValue, actualValue)
+            }
+
+            @TestAllUndirectedGraphs
+            fun `graph shouldn't change`(graph: UndirectedGraph<Int>) {
+                val graphStructure = setup(graph)
+                val defaultVerticesList = graphStructure.first
+
+                val v4 = defaultVerticesList[4]
+
+                graph.getOutgoingEdges(v4)
+
+                val actualGraph = graph.getVertices() to graph.getEdges().toSet()
+                val expectedGraph = graphStructure
+
+                assertEquals(expectedGraph, actualGraph)
+            }
+        }
+
+        @Nested
+        inner class `Vertex isn't in the graph` {
+            @TestAllUndirectedGraphs
+            fun `exception should be thrown`(graph: UndirectedGraph<Int>) {
+                assertThrows(NoSuchElementException::class.java) {
+                    graph.getOutgoingEdges(Vertex(2611, 2005))
+                }
+            }
+        }
+    }
 
     @Nested
-    inner class AddEdgeTest {}
+    inner class AddEdgeTest {
+        @Nested
+        inner class `Two vertices are in the graph` {
+            @Nested
+            inner class `Vertices are different` {
+                @TestAllUndirectedGraphs
+                fun `Added edge should be returned`(graph: UndirectedGraph<Int>) {
+                    val graphStructure = setup(graph)
+                    val defaultVerticesList = graphStructure.first
+
+                    val v0 = defaultVerticesList[0]
+                    val v4 = defaultVerticesList[4]
+
+                    val actualValue = graph.addEdge(v0, v4)
+                    val expectedValue = graph.getEdge(v0, v4)
+
+                    assertEquals(expectedValue, actualValue)
+                }
+
+                @TestAllUndirectedGraphs
+                fun `Edge should be added to graph`(graph: UndirectedGraph<Int>) {
+                    val graphStructure = setup(graph)
+                    val defaultVerticesList = graphStructure.first
+                    val defaultEdgesSet = graphStructure.second
+
+                    val v0 = defaultVerticesList[0]
+                    val v4 = defaultVerticesList[4]
+
+                    val newEdge = graph.addEdge(v4, v0)
+
+                    val actualEdges = graph.getEdges().toSet()
+                    val expectedEdges = defaultEdgesSet + newEdge
+
+                    assertEquals(expectedEdges, actualEdges)
+                }
+
+                @TestAllUndirectedGraphs
+                fun `vertices have to be added to each other's adjacency map values`(graph: UndirectedGraph<Int>) {
+                    val graphStructure = setup(graph)
+                    val defaultVerticesList = graphStructure.first
+
+                    val v0 = defaultVerticesList[0]
+                    val v1 = defaultVerticesList[1]
+                    val v2 = defaultVerticesList[2]
+                    val v3 = defaultVerticesList[3]
+                    val v4 = defaultVerticesList[4]
+
+                    graph.addEdge(v0, v2)
+
+                    val actualVertices1 = graph.getNeighbours(v0).toSet()
+                    val expectedVertices1 = setOf(v1, v2)
+
+                    val actualVertices2 = graph.getNeighbours(v2).toSet()
+                    val expectedVertices2 = setOf(v0, v1, v3)
+
+                    assertEquals(expectedVertices1, actualVertices1)
+                    assertEquals(expectedVertices2, actualVertices2)
+                }
+
+                @TestAllUndirectedGraphs
+                fun `edge has to be added to both vertices' outgoing edges map values`(graph: UndirectedGraph<Int>) {
+                    val graphStructure = setup(graph)
+                    val defaultVerticesList = graphStructure.first
+
+                    val v0 = defaultVerticesList[0]
+                    val v1 = defaultVerticesList[1]
+                    val v2 = defaultVerticesList[2]
+                    val v3 = defaultVerticesList[3]
+                    val v4 = defaultVerticesList[4]
+
+                    graph.addEdge(v3, v0)
+
+                    val actualEdges1 = graph.getOutgoingEdges(v0).toSet()
+                    val expectedEdges1 = setOf(graph.getEdge(v0, v1), graph.getEdge(v0, v3))
+
+                    val actualEdges2 = graph.getOutgoingEdges(v3).toSet()
+                    val expectedEdges2 = setOf(
+                        graph.getEdge(v3, v0),
+                        graph.getEdge(v3, v1),
+                        graph.getEdge(v3, v2),
+                        graph.getEdge(v3, v4)
+                    )
+
+
+                    assertEquals(expectedEdges1, actualEdges1)
+                    assertEquals(expectedEdges2, actualEdges2)
+                }
+
+                @TestAllUndirectedGraphs
+                fun `adding already existing edge shouldn't change graph`(graph: UndirectedGraph<Int>) {
+                    val graphStructure = setup(graph)
+                    val defaultVerticesList = graphStructure.first
+
+                    val v1 = defaultVerticesList[1]
+                    val v4 = defaultVerticesList[4]
+
+                    graph.addEdge(v4, v1)
+
+                    val expectedGraph = graphStructure
+                    val actualGraph = graph.getVertices() to graph.getEdges().toSet()
+
+                    assertEquals(expectedGraph, actualGraph)
+                }
+
+                @TestAllUndirectedGraphs
+                fun `adding already existing edge shouldn't change adjacency map`(graph: UndirectedGraph<Int>) {
+                    val graphStructure = setup(graph)
+                    val defaultVerticesList = graphStructure.first
+
+                    val v1 = defaultVerticesList[1]
+                    val v4 = defaultVerticesList[4]
+
+                    val expectedNeighbours1 = graph.getNeighbours(v1).toSet()
+                    val expectedNeighbours2 = graph.getNeighbours(v4).toSet()
+
+                    graph.addEdge(v4, v1)
+
+                    val actualNeighbours1 = graph.getNeighbours(v1).toSet()
+                    val actualNeighbours2 = graph.getNeighbours(v4).toSet()
+
+                    assertEquals(expectedNeighbours1, actualNeighbours1)
+                    assertEquals(expectedNeighbours2, actualNeighbours2)
+                }
+
+                @TestAllUndirectedGraphs
+                fun `adding already existing edge shouldn't change outgoing edges map`(graph: UndirectedGraph<Int>) {
+                    val graphStructure = setup(graph)
+                    val defaultVerticesList = graphStructure.first
+
+                    val v1 = defaultVerticesList[1]
+                    val v4 = defaultVerticesList[4]
+
+                    val expectedEdges1 = graph.getOutgoingEdges(v1).toSet()
+                    val expectedEdges2 = graph.getOutgoingEdges(v4).toSet()
+
+                    graph.addEdge(v4, v1)
+
+                    val actualEdges1 = graph.getOutgoingEdges(v1).toSet()
+                    val actualEdges2 = graph.getOutgoingEdges(v4).toSet()
+
+                    assertEquals(expectedEdges1, actualEdges1)
+                    assertEquals(expectedEdges2, actualEdges2)
+                }
+
+                @TestAllUndirectedGraphs
+                fun `adding edge with reversed arguments shouldn't change graph`(graph: UndirectedGraph<Int>) {
+                    val graphStructure = setup(graph)
+                    val defaultVerticesList = graphStructure.first
+
+                    val v1 = defaultVerticesList[1]
+                    val v4 = defaultVerticesList[4]
+
+                    graph.addEdge(v1, v4)
+
+                    val expectedGraph = graphStructure
+                    val actualGraph = graph.getVertices() to graph.getEdges().toSet()
+
+                    assertEquals(expectedGraph, actualGraph)
+                }
+
+                @TestAllUndirectedGraphs
+                fun `adding edge with reversed arguments shouldn't change adjacency map`(graph: UndirectedGraph<Int>) {
+                    val graphStructure = setup(graph)
+                    val defaultVerticesList = graphStructure.first
+
+                    val v1 = defaultVerticesList[1]
+                    val v4 = defaultVerticesList[4]
+
+                    val expectedNeighbours1 = graph.getNeighbours(v1).toSet()
+                    val expectedNeighbours2 = graph.getNeighbours(v4).toSet()
+
+                    graph.addEdge(v1, v4)
+
+                    val actualNeighbours1 = graph.getNeighbours(v1).toSet()
+                    val actualNeighbours2 = graph.getNeighbours(v4).toSet()
+
+                    assertEquals(expectedNeighbours1, actualNeighbours1)
+                    assertEquals(expectedNeighbours2, actualNeighbours2)
+                }
+
+                @TestAllUndirectedGraphs
+                fun `adding edge with reversed arguments shouldn't change outgoing edges map`(graph: UndirectedGraph<Int>) {
+                    val graphStructure = setup(graph)
+                    val defaultVerticesList = graphStructure.first
+
+                    val v1 = defaultVerticesList[1]
+                    val v4 = defaultVerticesList[4]
+
+                    val expectedEdges1 = graph.getOutgoingEdges(v1).toSet()
+                    val expectedEdges2 = graph.getOutgoingEdges(v4).toSet()
+
+                    graph.addEdge(v1, v4)
+
+                    val actualEdges1 = graph.getOutgoingEdges(v1).toSet()
+                    val actualEdges2 = graph.getOutgoingEdges(v4).toSet()
+
+                    assertEquals(expectedEdges1, actualEdges1)
+                    assertEquals(expectedEdges2, actualEdges2)
+                }
+            }
+
+            @Nested
+            inner class `Vertices are the same` {
+                @TestAllUndirectedGraphs
+                fun `exception should be thrown`(graph: UndirectedGraph<Int>) {
+                    val graphStructure = setup(graph)
+                    val defaultVerticesList = graphStructure.first
+
+                    val v2 = defaultVerticesList[2]
+
+                    assertThrows(IllegalArgumentException::class.java) {
+                        graph.addEdge(v2, v2)
+                    }
+                }
+            }
+        }
+
+        @Nested
+        inner class `One of the vertices isn't in the graph` {
+            @TestAllUndirectedGraphs
+            fun `first vertex isn't in the graph`(graph: UndirectedGraph<Int>) {
+                val graphStructure = setup(graph)
+                val defaultVerticesList = graphStructure.first
+
+                val v0 = defaultVerticesList[0]
+
+                assertThrows(IllegalArgumentException::class.java) {
+                    graph.addEdge(Vertex(2210, 2005), v0)
+                }
+            }
+
+            @TestAllUndirectedGraphs
+            fun `second vertex isn't in the graph`(graph: UndirectedGraph<Int>) {
+                val graphStructure = setup(graph)
+                val defaultVerticesList = graphStructure.first
+
+                val v0 = defaultVerticesList[0]
+
+                assertThrows(IllegalArgumentException::class.java) {
+                    graph.addEdge(v0, Vertex(2510, 1917))
+                }
+            }
+
+            @TestAllUndirectedGraphs
+            fun `both vertices aren't in the graph`(graph: UndirectedGraph<Int>) {
+                assertThrows(IllegalArgumentException::class.java) {
+                    graph.addEdge(Vertex(3010, 1978), Vertex(1002, 1982))
+                }
+            }
+        }
+    }
 
     @Nested
-    inner class RemoveEdgeTest {}
+    inner class RemoveEdgeTest {
+        @Nested
+        inner class `Edge is in the graph` {
+            @TestAllUndirectedGraphs
+            fun `removed edge should be returned`(graph: UndirectedGraph<Int>) {
+                val graphStructure = setup(graph)
+                val defaultVerticesList = graphStructure.first
+
+                val v1 = defaultVerticesList[1]
+                val v3 = defaultVerticesList[3]
+
+                val edgeToRemove = graph.getEdge(v3, v1)
+
+                val actualValue = graph.removeEdge(edgeToRemove)
+                val expectedValue = edgeToRemove
+
+                assertEquals(expectedValue, actualValue)
+            }
+
+            @TestAllUndirectedGraphs
+            fun `order of the arguments shouldn't matter`(graph: UndirectedGraph<Int>) {
+                val graphStructure = setup(graph)
+                val defaultVerticesList = graphStructure.first
+
+                val v1 = defaultVerticesList[1]
+                val v3 = defaultVerticesList[3]
+
+                val edgeToRemove = graph.getEdge(v1, v3)
+
+                val actualValue = graph.removeEdge(edgeToRemove)
+                val expectedValue = edgeToRemove
+
+                assertEquals(expectedValue, actualValue)
+            }
+
+            @TestAllUndirectedGraphs
+            fun `edge should be removed from graph`(graph: UndirectedGraph<Int>) {
+                val graphStructure = setup(graph)
+                val defaultVerticesList = graphStructure.first
+                val defaultEdgesSet = graphStructure.second
+
+                val v1 = defaultVerticesList[1]
+                val v4 = defaultVerticesList[4]
+
+                val edgeToRemove = graph.getEdge(v4, v1)
+                graph.removeEdge(edgeToRemove)
+
+                val actualEdges = graph.getEdges().toSet()
+                val expectedEdges = defaultEdgesSet - edgeToRemove
+
+                assertEquals(expectedEdges, actualEdges)
+            }
+
+            @TestAllUndirectedGraphs
+            fun `vertices should be removed from each other's adjacency map values`(graph: UndirectedGraph<Int>) {
+                val graphStructure = setup(graph)
+                val defaultVerticesList = graphStructure.first
+
+                val v0 = defaultVerticesList[0]
+                val v1 = defaultVerticesList[1]
+                val v2 = defaultVerticesList[2]
+                val v3 = defaultVerticesList[3]
+                val v4 = defaultVerticesList[4]
+
+                val edgeToRemove = graph.getEdge(v1, v2)
+                graph.removeEdge(edgeToRemove)
+
+                val actualVertices1 = graph.getNeighbours(v1).toSet()
+                val expectedVertices1 = setOf(v0, v3, v4)
+
+                val actualVertices2 = graph.getNeighbours(v2).toSet()
+                val expectedVertices2 = setOf(v3)
+
+                assertEquals(expectedVertices1, actualVertices1)
+                assertEquals(expectedVertices2, actualVertices2)
+            }
+
+            @TestAllUndirectedGraphs
+            fun `edge should be removed from vertices' outgoing edges map values`(graph: UndirectedGraph<Int>) {
+                val graphStructure = setup(graph)
+                val defaultVerticesList = graphStructure.first
+
+                val v0 = defaultVerticesList[0]
+                val v1 = defaultVerticesList[1]
+                val v2 = defaultVerticesList[2]
+                val v3 = defaultVerticesList[3]
+                val v4 = defaultVerticesList[4]
+
+                val edgeToRemove = graph.getEdge(v1, v2)
+                graph.removeEdge(edgeToRemove)
+
+                val actualEdges1 = graph.getOutgoingEdges(v1).toSet()
+                val expectedEdges1 = setOf(
+                    graph.getEdge(v1, v0),
+                    graph.getEdge(v1, v3),
+                    graph.getEdge(v1, v4),
+                )
+
+                val actualEdges2 = graph.getOutgoingEdges(v2).toSet()
+                val expectedEdges2 = setOf(graph.getEdge(v2, v3))
+
+                assertEquals(expectedEdges1, actualEdges1)
+                assertEquals(expectedEdges2, actualEdges2)
+            }
+        }
+
+        @Nested
+        inner class `Edge isn't in the graph` {
+            @TestAllUndirectedGraphs
+            fun `non-existing edge should throw an exception`(graph: UndirectedGraph<Int>) {
+                assertThrows(NoSuchElementException::class.java) {
+                    graph.removeEdge(Edge(Vertex(0,0), Vertex(1, 1)))
+                }
+            }
+        }
+    }
 
     @Nested
     inner class FindBridgesTest {

--- a/app/src/test/kotlin/model/UndirectedGraphTest.kt
+++ b/app/src/test/kotlin/model/UndirectedGraphTest.kt
@@ -4,26 +4,8 @@ import model.abstractGraph.Edge
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
-import org.junit.jupiter.api.extension.ExtensionContext
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.Arguments
-import org.junit.jupiter.params.provider.ArgumentsProvider
-import org.junit.jupiter.params.provider.ArgumentsSource
-import java.util.stream.Stream
-
-
-@ParameterizedTest(name = "{0}")
-@ArgumentsSource(WeightedAndUnweightedUndirectedGraphsProvider::class)
-@Target(AnnotationTarget.FUNCTION)
-@Retention(AnnotationRetention.RUNTIME)
-private annotation class TestBothUndirectedGraphs
-
-class WeightedAndUnweightedUndirectedGraphsProvider : ArgumentsProvider {
-    override fun provideArguments(context: ExtensionContext?): Stream<Arguments> = Stream.of(
-        Arguments.of(UndirectedGraph<Int>()),
-        Arguments.of(WeightedUndirectedGraph<Int>())
-    )
-}
+import util.annotations.TestAllUndirectedGraphs
+import util.setup
 
 class UndirectedGraphTest {
     private lateinit var graph: UndirectedGraph<Int>

--- a/app/src/test/kotlin/model/UndirectedGraphTest.kt
+++ b/app/src/test/kotlin/model/UndirectedGraphTest.kt
@@ -4,7 +4,26 @@ import model.abstractGraph.Edge
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
-import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.ArgumentsProvider
+import org.junit.jupiter.params.provider.ArgumentsSource
+import java.util.stream.Stream
+
+
+@ParameterizedTest(name = "{0}")
+@ArgumentsSource(WeightedAndUnweightedUndirectedGraphsProvider::class)
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+private annotation class TestBothUndirectedGraphs
+
+class WeightedAndUnweightedUndirectedGraphsProvider : ArgumentsProvider {
+    override fun provideArguments(context: ExtensionContext?): Stream<Arguments> = Stream.of(
+        Arguments.of(UndirectedGraph<Int>()),
+        Arguments.of(WeightedUndirectedGraph<Int>())
+    )
+}
 
 class UndirectedGraphTest {
     private lateinit var graph: UndirectedGraph<Int>

--- a/app/src/test/kotlin/model/UndirectedGraphTest.kt
+++ b/app/src/test/kotlin/model/UndirectedGraphTest.kt
@@ -34,6 +34,15 @@ class UndirectedGraphTest {
     }
 
     @Nested
+    inner class GetEdgeTest {}
+
+    @Nested
+    inner class GetNeighboursTest {}
+
+    @Nested
+    inner class GetOutgoingEdgesTest {}
+
+    @Nested
     inner class AddEdgeTest {}
 
     @Nested

--- a/app/src/test/kotlin/model/UndirectedGraphTest.kt
+++ b/app/src/test/kotlin/model/UndirectedGraphTest.kt
@@ -8,13 +8,6 @@ import util.annotations.TestAllUndirectedGraphs
 import util.setup
 
 class UndirectedGraphTest {
-    private lateinit var graph: UndirectedGraph<Int>
-
-    @BeforeEach
-    fun setup() {
-        graph = UndirectedGraph()
-    }
-
     @Nested
     inner class GetEdgeTest {}
 
@@ -34,8 +27,8 @@ class UndirectedGraphTest {
     inner class FindBridgesTest {
         @Nested
         inner class `All bridges should be found`() {
-            @Test
-            fun `if graph has one edge`() {
+            @TestAllUndirectedGraphs
+            fun `if graph has one edge`(graph: UndirectedGraph<Int>) {
                 val vertex0 = graph.addVertex(0)
                 val vertex1 = graph.addVertex(1)
 
@@ -45,8 +38,8 @@ class UndirectedGraphTest {
                 assertEquals(expectedBridges, actualBridges)
             }
 
-            @Test
-            fun `if two components are connected via one edge`() {
+            @TestAllUndirectedGraphs
+            fun `if two components are connected via one edge`(graph: UndirectedGraph<Int>) {
                 val v0 = graph.addVertex(0)
                 val v1 = graph.addVertex(1)
                 val v2 = graph.addVertex(2)
@@ -71,8 +64,8 @@ class UndirectedGraphTest {
                 assertEquals(expectedBridges, actualBridges)
             }
 
-            @Test
-            fun `if graph is chain-like`() {
+            @TestAllUndirectedGraphs
+            fun `if graph is chain-like`(graph: UndirectedGraph<Int>) {
                 val v0 = graph.addVertex(0)
                 val v1 = graph.addVertex(1)
                 val v2 = graph.addVertex(2)
@@ -88,8 +81,8 @@ class UndirectedGraphTest {
                 assertEquals(expectedBridges, actualBridges)
             }
 
-            @Test
-            fun `if graph is star-like`() {
+            @TestAllUndirectedGraphs
+            fun `if graph is star-like`(graph: UndirectedGraph<Int>) {
                 val v0 = graph.addVertex(0)
                 val v1 = graph.addVertex(1)
                 val v2 = graph.addVertex(2)
@@ -108,16 +101,16 @@ class UndirectedGraphTest {
 
         @Nested
         inner class `No bridge should be found`() {
-            @Test
-            fun `if graph has no vertices`() {
+            @TestAllUndirectedGraphs
+            fun `if graph has no vertices`(graph: UndirectedGraph<Int>) {
                 val expectedBridges = listOf<Edge<Int>>()
                 val actualBridges = graph.findBridges()
 
                 assertEquals(expectedBridges, actualBridges)
             }
 
-            @Test
-            fun `if graph has no edges`() {
+            @TestAllUndirectedGraphs
+            fun `if graph has no edges`(graph: UndirectedGraph<Int>) {
                 graph.apply {
                     addVertex(0)
                     addVertex(1)
@@ -130,8 +123,8 @@ class UndirectedGraphTest {
                 assertEquals(expectedBridges, actualBridges)
             }
 
-            @Test
-            fun `if graph is circle-like`() {
+            @TestAllUndirectedGraphs
+            fun `if graph is circle-like`(graph: UndirectedGraph<Int>) {
                 val v0 = graph.addVertex(0)
                 val v1 = graph.addVertex(1)
                 val v2 = graph.addVertex(2)
@@ -152,8 +145,8 @@ class UndirectedGraphTest {
                 assertEquals(expectedBridges, actualBridges)
             }
 
-            @Test
-            fun `if two components are connected via more than one edge`() {
+            @TestAllUndirectedGraphs
+            fun `if two components are connected via more than one edge`(graph: UndirectedGraph<Int>) {
                 val v0 = graph.addVertex(0)
                 val v1 = graph.addVertex(1)
                 val v2 = graph.addVertex(2)

--- a/app/src/test/kotlin/model/WeightedDirectedGraphTest.kt
+++ b/app/src/test/kotlin/model/WeightedDirectedGraphTest.kt
@@ -1,8 +1,19 @@
 package model
 
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 
 class WeightedDirectedGraphTest {
+    private lateinit var graph: WeightedDirectedGraph<Int>
+
+    @BeforeEach
+    fun init() {
+        graph = WeightedDirectedGraph()
+    }
+
+    @Nested
+    inner class GetWeightTest {}
+
     @Nested
     inner class AddEdgeTest {}
 

--- a/app/src/test/kotlin/model/WeightedDirectedGraphTest.kt
+++ b/app/src/test/kotlin/model/WeightedDirectedGraphTest.kt
@@ -2,6 +2,7 @@ package model
 
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
+import util.setup
 
 class WeightedDirectedGraphTest {
     private lateinit var graph: WeightedDirectedGraph<Int>

--- a/app/src/test/kotlin/model/WeightedDirectedGraphTest.kt
+++ b/app/src/test/kotlin/model/WeightedDirectedGraphTest.kt
@@ -1,8 +1,13 @@
 package model
 
+import model.abstractGraph.Edge
+import model.abstractGraph.Vertex
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
-import util.setup
+import org.junit.jupiter.api.Test
+import util.setupWeightedDirected
 
 class WeightedDirectedGraphTest {
     private lateinit var graph: WeightedDirectedGraph<Int>
@@ -13,13 +18,89 @@ class WeightedDirectedGraphTest {
     }
 
     @Nested
-    inner class GetWeightTest {}
+    inner class GetWeightTest {
+        @Nested
+        inner class `Edge is in the graph` {
+            @Test
+            fun `edge's weight should be returned`() {
+                val graphStructure = setupWeightedDirected(graph)
+                val defaultVertices = graphStructure.first
+
+                val v1 = defaultVertices[1]
+                val v3 = defaultVertices[3]
+                val edge = graph.getEdge(v3, v1)
+
+                val actualValue = graph.getWeight(edge)
+                val expectedValue = 3
+
+                assertEquals(expectedValue, actualValue)
+            }
+
+            @Test
+            fun `graph shouldn't change`() {
+                val graphStructure = setupWeightedDirected(graph)
+                val defaultVertices = graphStructure.first
+
+                val v1 = defaultVertices[1]
+                val v4 = defaultVertices[3]
+                val edge = graph.getEdge(v4, v1)
+
+                graph.getWeight(edge)
+
+                val actualGraph = graph.getVertices() to graph.getEdges().toSet()
+                val expectedGraph = graphStructure
+
+                assertEquals(expectedGraph, actualGraph)
+            }
+        }
+
+        @Nested
+        inner class `Edge isn't in the graph` {
+            @Test
+            fun `exception should be thrown`() {
+                assertThrows(NoSuchElementException::class.java) {
+                    graph.getWeight(Edge(Vertex(1505, 2), Vertex(9, 0)))
+                }
+            }
+        }
+    }
+
+    // most of the functionality is tested in the DirectedGraphTest class,
+    // as weighted graphs call super methods inside their methods
+    @Nested
+    inner class AddEdgeTest {
+        @Test
+        fun `added edge's weight should be added to weight map`() {
+            val v0 = graph.addVertex(30)
+            val v1 = graph.addVertex(31)
+
+            val newEdge = graph.addEdge(v0, v1, 62)
+
+            val actualValue = graph.getWeight(newEdge)
+            val expectedValue = 62
+
+            assertEquals(expectedValue, actualValue)
+        }
+    }
 
     @Nested
-    inner class AddEdgeTest {}
+    inner class RemoveEdgeTest {
+        @Test
+        fun `removed edge should be removed from the weight map`() {
+            val graphStructure = setupWeightedDirected(graph)
+            val defaultVertices = graphStructure.first
 
-    @Nested
-    inner class RemoveEdgeTest {}
+            val v1 = defaultVertices[1]
+            val v2 = defaultVertices[2]
+            val edge = graph.getEdge(v1, v2)
+
+            graph.removeEdge(edge)
+
+            assertThrows(NoSuchElementException::class.java) {
+                graph.getWeight(edge)
+            }
+        }
+    }
 
     @Nested
     inner class FindShortestPathDijkstraTest {}

--- a/app/src/test/kotlin/model/WeightedUndirectedGraphTest.kt
+++ b/app/src/test/kotlin/model/WeightedUndirectedGraphTest.kt
@@ -1,11 +1,14 @@
 package model
 
 import model.abstractGraph.Edge
+import model.abstractGraph.Vertex
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import util.setup
+import util.setupWeightedUndirected
 
 class WeightedUndirectedGraphTest {
     private lateinit var graph: WeightedUndirectedGraph<Int>
@@ -16,13 +19,89 @@ class WeightedUndirectedGraphTest {
     }
 
     @Nested
-    inner class GetWeightTest {}
+    inner class GetWeightTest {
+        @Nested
+        inner class `Edge is in the graph` {
+            @Test
+            fun `edge's weight should be returned`() {
+                val graphStructure = setupWeightedUndirected(graph)
+                val defaultVertices = graphStructure.first
+
+                val v1 = defaultVertices[1]
+                val v3 = defaultVertices[3]
+                val edge = graph.getEdge(v3, v1)
+
+                val actualValue = graph.getWeight(edge)
+                val expectedValue = 3
+
+                assertEquals(expectedValue, actualValue)
+            }
+
+            @Test
+            fun `graph shouldn't change`() {
+                val graphStructure = setupWeightedUndirected(graph)
+                val defaultVertices = graphStructure.first
+
+                val v1 = defaultVertices[1]
+                val v4 = defaultVertices[3]
+                val edge = graph.getEdge(v4, v1)
+
+                graph.getWeight(edge)
+
+                val actualGraph = graph.getVertices() to graph.getEdges().toSet()
+                val expectedGraph = graphStructure
+
+                assertEquals(expectedGraph, actualGraph)
+            }
+        }
+
+        @Nested
+        inner class `Edge isn't in the graph` {
+            @Test
+            fun `exception should be thrown`() {
+                assertThrows(NoSuchElementException::class.java) {
+                    graph.getWeight(Edge(Vertex(1505, 2), Vertex(9, 0)))
+                }
+            }
+        }
+    }
+
+    // most of the functionality is tested in the DirectedGraphTest class,
+    // as weighted graphs call super methods inside their methods
+    @Nested
+    inner class AddEdgeTest {
+        @Test
+        fun `added edge's weight should be added to weight map`() {
+            val v0 = graph.addVertex(30)
+            val v1 = graph.addVertex(31)
+
+            val newEdge = graph.addEdge(v0, v1, 62)
+
+            val actualValue = graph.getWeight(newEdge)
+            val expectedValue = 62
+
+            assertEquals(expectedValue, actualValue)
+        }
+    }
 
     @Nested
-    inner class AddEdgeTest {}
+    inner class RemoveEdgeTest {
+        @Test
+        fun `removed edge should be removed from the weight map`() {
+            val graphStructure = setupWeightedUndirected(graph)
+            val defaultVertices = graphStructure.first
 
-    @Nested
-    inner class RemoveEdgeTest {}
+            val v1 = defaultVertices[1]
+            val v2 = defaultVertices[2]
+            val edge = graph.getEdge(v1, v2)
+
+            graph.removeEdge(edge)
+
+            assertThrows(NoSuchElementException::class.java) {
+                graph.getWeight(edge)
+            }
+        }
+    }
 
     @Nested
     inner class FindShortestPathDijkstraTest {}

--- a/app/src/test/kotlin/model/WeightedUndirectedGraphTest.kt
+++ b/app/src/test/kotlin/model/WeightedUndirectedGraphTest.kt
@@ -15,6 +15,9 @@ class WeightedUndirectedGraphTest {
     }
 
     @Nested
+    inner class GetWeightTest {}
+
+    @Nested
     inner class AddEdgeTest {}
 
     @Nested

--- a/app/src/test/kotlin/model/WeightedUndirectedGraphTest.kt
+++ b/app/src/test/kotlin/model/WeightedUndirectedGraphTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import util.setup
 
 class WeightedUndirectedGraphTest {
     private lateinit var graph: WeightedUndirectedGraph<Int>

--- a/app/src/test/kotlin/model/abstractGraph/GraphTest.kt
+++ b/app/src/test/kotlin/model/abstractGraph/GraphTest.kt
@@ -251,7 +251,8 @@ class GraphTest {
                     val expectedEdges = setOf(
                         graph.getEdge(newV0, newV1),
                         graph.getEdge(newV3, newV2),
-                        graph.getEdge(newV2, newV1)
+                        graph.getEdge(newV2, newV1),
+                        graph.getEdge(newV3, newV1)
                     )
 
                     assertEquals(expectedEdges, actualEdges)

--- a/app/src/test/kotlin/model/abstractGraph/GraphTest.kt
+++ b/app/src/test/kotlin/model/abstractGraph/GraphTest.kt
@@ -1,55 +1,12 @@
 package model.abstractGraph
 
-import model.DirectedGraph
-import model.UndirectedGraph
-import model.WeightedDirectedGraph
-import model.WeightedUndirectedGraph
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Nested
-import org.junit.jupiter.api.extension.ExtensionContext
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.Arguments
-import org.junit.jupiter.params.provider.ArgumentsProvider
-import org.junit.jupiter.params.provider.ArgumentsSource
-import java.util.stream.Stream
-
-@ParameterizedTest(name = "{0}")
-@ArgumentsSource(AllGraphTypesProvider::class)
-@Target(AnnotationTarget.FUNCTION)
-@Retention(AnnotationRetention.RUNTIME)
-private annotation class TestAllGraphTypes
-
-class AllGraphTypesProvider : ArgumentsProvider {
-    override fun provideArguments(context: ExtensionContext?): Stream<Arguments> = Stream.of(
-        Arguments.of(UndirectedGraph<Int>()),
-        Arguments.of(DirectedGraph<Int>()),
-        Arguments.of(WeightedUndirectedGraph<Int>()),
-        Arguments.of(WeightedDirectedGraph<Int>())
-    )
-}
-
-fun setup(graph: Graph<Int>): Pair<List<Vertex<Int>>, Set<Edge<Int>>> {
-    val v0 = graph.addVertex(0)
-    val v1 = graph.addVertex(1)
-    val v2 = graph.addVertex(2)
-    val v3 = graph.addVertex(3)
-    val v4 = graph.addVertex(4)
-
-    val defaultVerticesList = listOf(v0, v1, v2, v3, v4)
-
-    val defaultEdgesSet = setOf(
-        graph.addEdge(v0, v1),
-        graph.addEdge(v1, v2),
-        graph.addEdge(v2, v3),
-        graph.addEdge(v3, v4),
-        graph.addEdge(v4, v1)
-    )
-
-    return defaultVerticesList to defaultEdgesSet
-}
-
-val emptyVerticesList = listOf<Vertex<Int>>()
-val emptyEdgesSet = setOf<Edge<Int>>()
+import util.annotations.TestAllGraphTypes
+import util.setup
+import util.emptyVerticesList
+import util.emptyEdgesSet
+import util.emptyGraph
 
 class GraphTest {
     @Nested
@@ -95,7 +52,7 @@ class GraphTest {
                 graph.getVertices()
 
                 val actualGraph = graph.getVertices() to graph.getEdges().toSet()
-                val expectedGraph = emptyVerticesList to emptyEdgesSet
+                val expectedGraph = emptyGraph
 
                 assertEquals(expectedGraph, actualGraph)
             }
@@ -145,7 +102,7 @@ class GraphTest {
                 graph.getEdges()
 
                 val actualGraph = graph.getVertices() to graph.getEdges().toSet()
-                val expectedGraph = emptyVerticesList to emptyEdgesSet
+                val expectedGraph = emptyGraph
 
                 assertEquals(expectedGraph, actualGraph)
             }

--- a/app/src/test/kotlin/util/annotations/TestAllDirectedGraphs.kt
+++ b/app/src/test/kotlin/util/annotations/TestAllDirectedGraphs.kt
@@ -1,0 +1,11 @@
+package util.annotations
+
+import util.annotations.argumentProviders.WeightedAndUnweightedDirectedGraphsProvider
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ArgumentsSource
+
+@ParameterizedTest(name = "{0}")
+@ArgumentsSource(WeightedAndUnweightedDirectedGraphsProvider::class)
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class TestAllDirectedGraphs

--- a/app/src/test/kotlin/util/annotations/TestAllGraphTypes.kt
+++ b/app/src/test/kotlin/util/annotations/TestAllGraphTypes.kt
@@ -1,0 +1,12 @@
+package util.annotations
+
+import util.annotations.argumentProviders.AllGraphTypesProvider
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ArgumentsSource
+
+@ParameterizedTest(name = "{0}")
+@ArgumentsSource(AllGraphTypesProvider::class)
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class TestAllGraphTypes
+

--- a/app/src/test/kotlin/util/annotations/TestAllUndirectedGraphs.kt
+++ b/app/src/test/kotlin/util/annotations/TestAllUndirectedGraphs.kt
@@ -1,0 +1,11 @@
+package util.annotations
+
+import util.annotations.argumentProviders.WeightedAndUnweightedUndirectedGraphsProvider
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ArgumentsSource
+
+@ParameterizedTest(name = "{0}")
+@ArgumentsSource(WeightedAndUnweightedUndirectedGraphsProvider::class)
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class TestAllUndirectedGraphs

--- a/app/src/test/kotlin/util/annotations/argumentProviders/AllGraphTypesProvider.kt
+++ b/app/src/test/kotlin/util/annotations/argumentProviders/AllGraphTypesProvider.kt
@@ -1,0 +1,19 @@
+package util.annotations.argumentProviders
+
+import model.DirectedGraph
+import model.UndirectedGraph
+import model.WeightedDirectedGraph
+import model.WeightedUndirectedGraph
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.ArgumentsProvider
+import java.util.stream.Stream
+
+class AllGraphTypesProvider : ArgumentsProvider {
+    override fun provideArguments(context: ExtensionContext?): Stream<Arguments> = Stream.of(
+        Arguments.of(UndirectedGraph<Int>()),
+        Arguments.of(DirectedGraph<Int>()),
+        Arguments.of(WeightedUndirectedGraph<Int>()),
+        Arguments.of(WeightedDirectedGraph<Int>())
+    )
+}

--- a/app/src/test/kotlin/util/annotations/argumentProviders/WeightedAndUnweightedDirectedGraphsProvider.kt
+++ b/app/src/test/kotlin/util/annotations/argumentProviders/WeightedAndUnweightedDirectedGraphsProvider.kt
@@ -1,0 +1,15 @@
+package util.annotations.argumentProviders
+
+import model.DirectedGraph
+import model.WeightedDirectedGraph
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.ArgumentsProvider
+import java.util.stream.Stream
+
+class WeightedAndUnweightedDirectedGraphsProvider : ArgumentsProvider {
+    override fun provideArguments(context: ExtensionContext?): Stream<Arguments> = Stream.of(
+        Arguments.of(DirectedGraph<Int>()),
+        Arguments.of(WeightedDirectedGraph<Int>())
+    )
+}

--- a/app/src/test/kotlin/util/annotations/argumentProviders/WeightedAndUnweightedUndirectedGraphsProvider.kt
+++ b/app/src/test/kotlin/util/annotations/argumentProviders/WeightedAndUnweightedUndirectedGraphsProvider.kt
@@ -1,0 +1,15 @@
+package util.annotations.argumentProviders
+
+import model.UndirectedGraph
+import model.WeightedUndirectedGraph
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.ArgumentsProvider
+import java.util.stream.Stream
+
+class WeightedAndUnweightedUndirectedGraphsProvider : ArgumentsProvider {
+    override fun provideArguments(context: ExtensionContext?): Stream<Arguments> = Stream.of(
+        Arguments.of(UndirectedGraph<Int>()),
+        Arguments.of(WeightedUndirectedGraph<Int>())
+    )
+}

--- a/app/src/test/kotlin/util/emptyGraphs.kt
+++ b/app/src/test/kotlin/util/emptyGraphs.kt
@@ -8,7 +8,7 @@ import model.abstractGraph.Edge
 import model.abstractGraph.Vertex
 
 val emptyDirectedGraph = DirectedGraph<Int>()
-val emptyUndirectedGrap = UndirectedGraph<Int>()
+val emptyUndirectedGraph = UndirectedGraph<Int>()
 
 val emptyWDGrapgh = WeightedDirectedGraph<Int>()
 val emptyWUGrapgh = WeightedUndirectedGraph<Int>()

--- a/app/src/test/kotlin/util/emptyGraphs.kt
+++ b/app/src/test/kotlin/util/emptyGraphs.kt
@@ -1,0 +1,19 @@
+package util
+
+import model.DirectedGraph
+import model.UndirectedGraph
+import model.WeightedDirectedGraph
+import model.WeightedUndirectedGraph
+import model.abstractGraph.Edge
+import model.abstractGraph.Vertex
+
+val emptyDirectedGraph = DirectedGraph<Int>()
+val emptyUndirectedGrap = UndirectedGraph<Int>()
+
+val emptyWDGrapgh = WeightedDirectedGraph<Int>()
+val emptyWUGrapgh = WeightedUndirectedGraph<Int>()
+
+val emptyVerticesList = listOf<Vertex<Int>>()
+val emptyEdgesSet = setOf<Edge<Int>>()
+
+val emptyGraph = emptyVerticesList to emptyEdgesSet

--- a/app/src/test/kotlin/util/setup.kt
+++ b/app/src/test/kotlin/util/setup.kt
@@ -18,7 +18,8 @@ fun setup(graph: Graph<Int>): Pair<List<Vertex<Int>>, Set<Edge<Int>>> {
         graph.addEdge(v1, v2),
         graph.addEdge(v2, v3),
         graph.addEdge(v3, v4),
-        graph.addEdge(v4, v1)
+        graph.addEdge(v4, v1),
+        graph.addEdge(v3, v1)
     )
 
     return defaultVerticesList to defaultEdgesSet

--- a/app/src/test/kotlin/util/setup.kt
+++ b/app/src/test/kotlin/util/setup.kt
@@ -1,0 +1,25 @@
+package util
+
+import model.abstractGraph.Edge
+import model.abstractGraph.Graph
+import model.abstractGraph.Vertex
+
+fun setup(graph: Graph<Int>): Pair<List<Vertex<Int>>, Set<Edge<Int>>> {
+    val v0 = graph.addVertex(0)
+    val v1 = graph.addVertex(1)
+    val v2 = graph.addVertex(2)
+    val v3 = graph.addVertex(3)
+    val v4 = graph.addVertex(4)
+
+    val defaultVerticesList = listOf(v0, v1, v2, v3, v4)
+
+    val defaultEdgesSet = setOf(
+        graph.addEdge(v0, v1),
+        graph.addEdge(v1, v2),
+        graph.addEdge(v2, v3),
+        graph.addEdge(v3, v4),
+        graph.addEdge(v4, v1)
+    )
+
+    return defaultVerticesList to defaultEdgesSet
+}

--- a/app/src/test/kotlin/util/setup.kt
+++ b/app/src/test/kotlin/util/setup.kt
@@ -3,6 +3,8 @@ package util
 import model.abstractGraph.Edge
 import model.abstractGraph.Graph
 import model.abstractGraph.Vertex
+import model.WeightedUndirectedGraph
+import model.WeightedDirectedGraph
 
 fun setup(graph: Graph<Int>): Pair<List<Vertex<Int>>, Set<Edge<Int>>> {
     val v0 = graph.addVertex(0)
@@ -20,6 +22,48 @@ fun setup(graph: Graph<Int>): Pair<List<Vertex<Int>>, Set<Edge<Int>>> {
         graph.addEdge(v3, v4),
         graph.addEdge(v4, v1),
         graph.addEdge(v3, v1)
+    )
+
+    return defaultVerticesList to defaultEdgesSet
+}
+
+fun setupWeightedDirected(graph: WeightedDirectedGraph<Int>): Pair<List<Vertex<Int>>, Set<Edge<Int>>> {
+    val v0 = graph.addVertex(0)
+    val v1 = graph.addVertex(1)
+    val v2 = graph.addVertex(2)
+    val v3 = graph.addVertex(3)
+    val v4 = graph.addVertex(4)
+
+    val defaultVerticesList = listOf(v0, v1, v2, v3, v4)
+
+    val defaultEdgesSet = setOf(
+        graph.addEdge(v0, v1, -3),
+        graph.addEdge(v1, v2, -2),
+        graph.addEdge(v2, v3, -1),
+        graph.addEdge(v3, v4, 1),
+        graph.addEdge(v4, v1, 2),
+        graph.addEdge(v3, v1, 3)
+    )
+
+    return defaultVerticesList to defaultEdgesSet
+}
+
+fun setupWeightedUndirected(graph: WeightedUndirectedGraph<Int>): Pair<List<Vertex<Int>>, Set<Edge<Int>>> {
+    val v0 = graph.addVertex(0)
+    val v1 = graph.addVertex(1)
+    val v2 = graph.addVertex(2)
+    val v3 = graph.addVertex(3)
+    val v4 = graph.addVertex(4)
+
+    val defaultVerticesList = listOf(v0, v1, v2, v3, v4)
+
+    val defaultEdgesSet = setOf(
+        graph.addEdge(v0, v1, -3),
+        graph.addEdge(v1, v2, -2),
+        graph.addEdge(v2, v3, -1),
+        graph.addEdge(v3, v4, 1),
+        graph.addEdge(v4, v1, 2),
+        graph.addEdge(v3, v1, 3)
     )
 
     return defaultVerticesList to defaultEdgesSet


### PR DESCRIPTION
Add parameterized tests (using custom annotations) for directed and undirected graphs that run tests on all their inheritors.

Add basic tests for weighted graphs.

Create util package and move all annotation and argument provider classes, util methods there.

Fix check if vertices are in the graph in addEdge method (sorry, was too lazy to create separate branch...).
