### PR TITLE
Fix removing edge from weightMap

### DIFF
--- a/app/src/main/kotlin/model/WeightedDirectedGraph.kt
+++ b/app/src/main/kotlin/model/WeightedDirectedGraph.kt
@@ -19,6 +19,14 @@ class WeightedDirectedGraph<D> : DirectedGraph<D>() {
     // In case weight is not passed, set it to default value = 1
     override fun addEdge(vertex1: Vertex<D>, vertex2: Vertex<D>) = addEdge(vertex1, vertex2, 1)
 
+    override fun removeEdge(edgeToRemove: Edge<D>): Edge<D> {
+        val removedEdge = super.removeEdge(edgeToRemove)
+
+        weightMap.remove(edgeToRemove)
+
+        return removedEdge
+    }
+
     fun getWeight(edge: Edge<D>): Int {
         val weight = weightMap[edge]
             ?: throw NoSuchElementException(

--- a/app/src/main/kotlin/model/WeightedUndirectedGraph.kt
+++ b/app/src/main/kotlin/model/WeightedUndirectedGraph.kt
@@ -20,6 +20,14 @@ class WeightedUndirectedGraph<D> : UndirectedGraph<D>() {
     // In case weight is not passed, set it to default value = 1
     override fun addEdge(vertex1: Vertex<D>, vertex2: Vertex<D>) = addEdge(vertex1, vertex2, 1)
 
+    override fun removeEdge(edgeToRemove: Edge<D>): Edge<D> {
+        val removedEdge = super.removeEdge(edgeToRemove)
+
+        weightMap.remove(edgeToRemove)
+
+        return removedEdge
+    }
+
     fun getWeight(edge: Edge<D>): Int {
         val weight = weightMap[edge]
             ?: throw NoSuchElementException(


### PR DESCRIPTION
Add removeEdge override methods to weighted graphs that call super methods and remove edge from weight map.