### PR TITLE
Implement tests for Kosaraju's SCC search

### DIFF
--- a/app/src/main/kotlin/model/DirectedGraph.kt
+++ b/app/src/main/kotlin/model/DirectedGraph.kt
@@ -63,7 +63,7 @@ open class DirectedGraph<D> : Graph<D>() {
         fun auxiliaryDFS(srcVertex: Vertex<D>, componentList: ArrayList<Vertex<D>>) {
             visited[srcVertex] = true
             componentList.add(srcVertex)
-            adjacencyMap[srcVertex]?.forEach { vertex2 ->
+            getNeighbours(srcVertex).forEach { vertex2 ->
                 if (visited[vertex2] != true) {
                     auxiliaryDFS(vertex2, componentList)
                 }
@@ -82,7 +82,7 @@ open class DirectedGraph<D> : Graph<D>() {
         fun reverseDFS(vertex: Vertex<D>, componentList: MutableSet<Vertex<D>>) {
             visited[vertex] = true
             componentList.add(vertex)
-            adjacencyMap[vertex]?.forEach { vertex2 ->
+            getNeighbours(vertex).forEach { vertex2 ->
                 if (visited[vertex2] != true) {
                     reverseDFS(vertex2, componentList)
                 }

--- a/app/src/main/kotlin/model/DirectedGraph.kt
+++ b/app/src/main/kotlin/model/DirectedGraph.kt
@@ -12,7 +12,7 @@ open class DirectedGraph<D> : Graph<D>() {
         if (vertex1 !in vertices || vertex2 !in vertices)
             throw IllegalArgumentException(
                 "One of the vertices (${vertex1.id}, ${vertex1.data}) and " +
-                    "(${vertex2.id}, ${vertex2.data}) isn't in the graph"
+                        "(${vertex2.id}, ${vertex2.data}) isn't in the graph"
             )
 
         // Don't do anything if the edge is already in the graph
@@ -30,7 +30,7 @@ open class DirectedGraph<D> : Graph<D>() {
     override fun removeEdge(edgeToRemove: Edge<D>): Edge<D> {
         if (edgeToRemove !in edges) throw NoSuchElementException(
             "Edge between vertices (${edgeToRemove.vertex1.id}, ${edgeToRemove.vertex1.data}) and " +
-                "(${edgeToRemove.vertex2.id}, ${edgeToRemove.vertex2.data}) isn't in the graph"
+                    "(${edgeToRemove.vertex2.id}, ${edgeToRemove.vertex2.data}) isn't in the graph"
         )
 
         val vertex1 = edgeToRemove.vertex1
@@ -75,14 +75,14 @@ open class DirectedGraph<D> : Graph<D>() {
             if (visited[vertex] != true) auxiliaryDFS(vertex, component)
         }
 
-        reverseGraph()
+        val reversedEdgesMap = reverseEdgesMap()
         visited.clear()
         component.clear()
 
         fun reverseDFS(vertex: Vertex<D>, componentList: MutableSet<Vertex<D>>) {
             visited[vertex] = true
             componentList.add(vertex)
-            getNeighbours(vertex).forEach { vertex2 ->
+            reversedEdgesMap[vertex]?.forEach { vertex2 ->
                 if (visited[vertex2] != true) {
                     reverseDFS(vertex2, componentList)
                 }
@@ -100,15 +100,13 @@ open class DirectedGraph<D> : Graph<D>() {
         return sccList
     }
 
-    private fun reverseGraph() {
-        val reversedAdjacencyMap = mutableMapOf<Vertex<D>, MutableSet<Vertex<D>>>()
-        vertices.forEach { reversedAdjacencyMap[it] = mutableSetOf() }
-        adjacencyMap.forEach { (from, toList) ->
-            toList.forEach { to ->
-                reversedAdjacencyMap[to]?.add(from)
-            }
+    private fun reverseEdgesMap(): Map<Vertex<D>, MutableSet<Vertex<D>>> {
+        val reversedEdgesMap = mutableMapOf<Vertex<D>, MutableSet<Vertex<D>>>()
+        vertices.forEach { reversedEdgesMap[it] = mutableSetOf() }
+        edges.forEach { edge ->
+            reversedEdgesMap[edge.vertex2]?.add(edge.vertex1)
         }
-        adjacencyMap.clear()
-        adjacencyMap.putAll(reversedAdjacencyMap)
+        return reversedEdgesMap
     }
 }
+

--- a/app/src/main/kotlin/model/DirectedGraph.kt
+++ b/app/src/main/kotlin/model/DirectedGraph.kt
@@ -54,36 +54,46 @@ open class DirectedGraph<D> : Graph<D>() {
     }
 
     // SCC - Strongly Connected Components (by Kosaraju)
-    fun findSCC(): ArrayList<ArrayList<Vertex<D>>> {
+    fun findSCC(): MutableSet<MutableSet<Vertex<D>>> {
         val visited = mutableMapOf<Vertex<D>, Boolean>().withDefault { false }
         val stack = ArrayDeque<Vertex<D>>()
         val component = arrayListOf<Vertex<D>>()
-        val sccList: ArrayList<ArrayList<Vertex<D>>> = arrayListOf()
+        val sccList: MutableSet<MutableSet<Vertex<D>>> = mutableSetOf()
 
         fun auxiliaryDFS(srcVertex: Vertex<D>, componentList: ArrayList<Vertex<D>>) {
             visited[srcVertex] = true
             componentList.add(srcVertex)
             adjacencyMap[srcVertex]?.forEach { vertex2 ->
-                if (visited[vertex2] != null && visited[vertex2] != true) {
+                if (visited[vertex2] != true) {
                     auxiliaryDFS(vertex2, componentList)
                 }
             }
             stack.add(srcVertex)
         }
 
-        for (vertex in vertices) {
-            if (visited[vertex] != null && visited[vertex] != true) auxiliaryDFS(vertex, component)
+        vertices.forEach { vertex ->
+            if (visited[vertex] != true) auxiliaryDFS(vertex, component)
         }
 
         reverseGraph()
         visited.clear()
         component.clear()
 
+        fun reverseDFS(vertex: Vertex<D>, componentList: MutableSet<Vertex<D>>) {
+            visited[vertex] = true
+            componentList.add(vertex)
+            adjacencyMap[vertex]?.forEach { vertex2 ->
+                if (visited[vertex2] != true) {
+                    reverseDFS(vertex2, componentList)
+                }
+            }
+        }
+
         while (stack.isNotEmpty()) {
             val vertex = stack.removeLast()
-            if (visited[vertex] != null && visited[vertex] != true) {
-                val currentComponent = arrayListOf<Vertex<D>>()
-                auxiliaryDFS(vertex, currentComponent)
+            if (visited[vertex] != true) {
+                val currentComponent = mutableSetOf<Vertex<D>>()
+                reverseDFS(vertex, currentComponent)
                 sccList.add(currentComponent)
             }
         }
@@ -92,10 +102,10 @@ open class DirectedGraph<D> : Graph<D>() {
 
     private fun reverseGraph() {
         val reversedAdjacencyMap = mutableMapOf<Vertex<D>, MutableSet<Vertex<D>>>()
-        for (vertex in vertices) {
-            adjacencyMap[vertex]?.forEach { vertex2 ->
-                reversedAdjacencyMap[vertex2] = reversedAdjacencyMap[vertex2] ?: mutableSetOf()
-                reversedAdjacencyMap[vertex2]?.add(vertex)
+        vertices.forEach { reversedAdjacencyMap[it] = mutableSetOf() }
+        adjacencyMap.forEach { (from, toList) ->
+            toList.forEach { to ->
+                reversedAdjacencyMap[to]?.add(from)
             }
         }
         adjacencyMap.clear()

--- a/app/src/test/kotlin/model/DirectedGraphTest.kt
+++ b/app/src/test/kotlin/model/DirectedGraphTest.kt
@@ -3,7 +3,9 @@ package model
 import model.abstractGraph.Edge
 import model.abstractGraph.Vertex
 import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 import util.annotations.TestAllDirectedGraphs
 import util.emptyEdgesSet
 import util.emptyVerticesList
@@ -429,12 +431,165 @@ class DirectedGraphTest {
             @TestAllDirectedGraphs
             fun `non-existing edge should throw an exception`(graph: DirectedGraph<Int>) {
                 assertThrows(NoSuchElementException::class.java) {
-                    graph.removeEdge(Edge(Vertex(0,0), Vertex(1, 1)))
+                    graph.removeEdge(Edge(Vertex(0, 0), Vertex(1, 1)))
                 }
             }
         }
     }
 
     @Nested
-    inner class FindSCCTest {}
+    inner class FindSCCTest {
+        @Nested
+        inner class `SCC should return not empty array`() {
+            @TestAllDirectedGraphs
+            fun `graph has two connected vertices`() {
+                val graph = DirectedGraph<Int>()
+                val v1 = graph.addVertex(1)
+                val v2 = graph.addVertex(2)
+
+                graph.addEdge(v1, v2)
+                graph.addEdge(v2, v1)
+
+                val actualValue = graph.findSCC()
+                val expectedValue = mutableSetOf(mutableSetOf(v1, v2))
+
+                assertEquals(expectedValue, actualValue)
+            }
+
+            @TestAllDirectedGraphs
+            fun `complex graph`() {
+                val graph = DirectedGraph<Int>()
+                val v1 = graph.addVertex(1)
+                val v2 = graph.addVertex(2)
+                val v3 = graph.addVertex(3)
+                val v4 = graph.addVertex(4)
+
+                graph.addEdge(v1, v2)
+                graph.addEdge(v2, v3)
+                graph.addEdge(v3, v1)
+                graph.addEdge(v3, v4)
+
+                val actualValue = graph.findSCC()
+                val expectedValue = mutableSetOf(mutableSetOf(v1, v2, v3), mutableSetOf(v4))
+
+                assertEquals(expectedValue, actualValue)
+            }
+
+            @TestAllDirectedGraphs
+            fun `graph has multiple SCCs`() {
+                val graph = DirectedGraph<Int>()
+                val v1 = graph.addVertex(1)
+                val v2 = graph.addVertex(2)
+                val v3 = graph.addVertex(3)
+                val v4 = graph.addVertex(4)
+                val v5 = graph.addVertex(5)
+
+                graph.addEdge(v1, v2)
+                graph.addEdge(v2, v1)
+                graph.addEdge(v3, v4)
+                graph.addEdge(v4, v3)
+                graph.addEdge(v5, v1)
+
+                val actualValue = graph.findSCC()
+                val expectedValue = mutableSetOf(mutableSetOf(v3, v4), mutableSetOf(v1, v2), mutableSetOf(v5))
+
+                assertEquals(expectedValue, actualValue)
+            }
+        }
+
+        @Nested
+        inner class `SCC should return single-element SCCs`() {
+
+            @TestAllDirectedGraphs
+            fun `graph has single vertex`() {
+                val graph = DirectedGraph<Int>()
+                val v1 = graph.addVertex(1)
+
+                val actualValue = graph.findSCC()
+                val expectedValue = mutableSetOf(mutableSetOf(v1))
+
+                assertEquals(expectedValue, actualValue)
+            }
+
+            @TestAllDirectedGraphs
+            fun `graph with multiple disconnected vertices`() {
+                val graph = DirectedGraph<Int>()
+                val v1 = graph.addVertex(1)
+                val v2 = graph.addVertex(2)
+                val v3 = graph.addVertex(3)
+                val v4 = graph.addVertex(4)
+
+                val actualValue = graph.findSCC()
+                val expectedValue = mutableSetOf(mutableSetOf(v1), mutableSetOf(v2), mutableSetOf(v3), mutableSetOf(v4))
+
+                assertEquals(expectedValue, actualValue)
+            }
+        }
+        @Nested
+        inner class `Additional edge cases`() {
+
+            @TestAllDirectedGraphs
+            fun `empty graph`() {
+                val graph = DirectedGraph<Int>()
+
+                val actualValue = graph.findSCC()
+                val expectedValue = mutableSetOf<MutableSet<Vertex<Int>>>()
+
+                assertEquals(expectedValue, actualValue)
+            }
+
+            @Disabled("Our model doesn't support edge from vertex to itself, check DirectedGraph.kt")
+            @TestAllDirectedGraphs
+            fun `graph with self-loops`() {
+                val graph = DirectedGraph<Int>()
+                val v1 = graph.addVertex(1)
+                val v2 = graph.addVertex(2)
+
+                graph.addEdge(v1, v1)
+                graph.addEdge(v2, v2)
+
+                val actualValue = graph.findSCC()
+                val expectedValue = mutableSetOf(mutableSetOf(v1), mutableSetOf(v2))
+
+                assertEquals(expectedValue, actualValue)
+            }
+
+            @TestAllDirectedGraphs
+            fun `linear graph`() {
+                val graph = DirectedGraph<Int>()
+                val v1 = graph.addVertex(1)
+                val v2 = graph.addVertex(2)
+                val v3 = graph.addVertex(3)
+
+                graph.addEdge(v1, v2)
+                graph.addEdge(v2, v3)
+
+                val actualValue = graph.findSCC()
+                val expectedValue = mutableSetOf(mutableSetOf(v3), mutableSetOf(v2), mutableSetOf(v1))
+
+                assertEquals(expectedValue, actualValue)
+            }
+
+            @TestAllDirectedGraphs
+            fun `graph with cycles and tail`() {
+                val graph = DirectedGraph<Int>()
+                val v1 = graph.addVertex(1)
+                val v2 = graph.addVertex(2)
+                val v3 = graph.addVertex(3)
+                val v4 = graph.addVertex(4)
+                val v5 = graph.addVertex(5)
+
+                graph.addEdge(v1, v2)
+                graph.addEdge(v2, v3)
+                graph.addEdge(v3, v1)
+                graph.addEdge(v4, v3)
+                graph.addEdge(v4, v5)
+
+                val actualValue = graph.findSCC()
+                val expectedValue = mutableSetOf(mutableSetOf(v1, v2, v3), mutableSetOf(v4), mutableSetOf(v5))
+
+                assertEquals(expectedValue, actualValue)
+            }
+        }
+    }
 }

--- a/app/src/test/kotlin/model/DirectedGraphTest.kt
+++ b/app/src/test/kotlin/model/DirectedGraphTest.kt
@@ -678,5 +678,99 @@ class DirectedGraphTest {
                 assertEquals(expectedValue, actualValue)
             }
         }
+        @Nested
+        inner class `Side-effects check`() {
+            @TestAllDirectedGraphs
+            fun `check vertices in complex graph`() {
+                val graph = DirectedGraph<Int>()
+                val v1 = graph.addVertex(1)
+                val v2 = graph.addVertex(2)
+                val v3 = graph.addVertex(3)
+                val v4 = graph.addVertex(4)
+
+                graph.addEdge(v1, v2)
+                graph.addEdge(v2, v3)
+                graph.addEdge(v3, v1)
+                graph.addEdge(v3, v4)
+
+                val edgesBeforeReverse = graph.getEdges()
+                val expectedValue = graph.getVertices()
+                graph.findSCC()
+                val actualValue = graph.getVertices()
+
+                assertEquals(expectedValue, actualValue)
+            }
+
+            @TestAllDirectedGraphs
+            fun `check edges in complex graph`() {
+                val graph = DirectedGraph<Int>()
+                val v1 = graph.addVertex(1)
+                val v2 = graph.addVertex(2)
+                val v3 = graph.addVertex(3)
+                val v4 = graph.addVertex(4)
+
+                graph.addEdge(v1, v2)
+                graph.addEdge(v2, v3)
+                graph.addEdge(v3, v1)
+                graph.addEdge(v3, v4)
+
+
+                val expectedValue = graph.getEdges()
+
+                graph.findSCC()
+
+                val actualValue = graph.getEdges()
+
+                assertEquals(expectedValue, actualValue)
+            }
+
+            @TestAllDirectedGraphs
+            fun `check edges in graph with cycles and tail`() {
+                val graph = DirectedGraph<Int>()
+                val v1 = graph.addVertex(1)
+                val v2 = graph.addVertex(2)
+                val v3 = graph.addVertex(3)
+                val v4 = graph.addVertex(4)
+                val v5 = graph.addVertex(5)
+
+                graph.addEdge(v1, v2)
+                graph.addEdge(v2, v3)
+                graph.addEdge(v3, v1)
+                graph.addEdge(v4, v3)
+                graph.addEdge(v4, v5)
+
+                val expectedValue = graph.getEdges()
+
+                graph.findSCC()
+
+                val actualValue = graph.getEdges()
+
+                assertEquals(expectedValue, actualValue)
+            }
+
+            @TestAllDirectedGraphs
+            fun `check vertices graph with cycles and tail`() {
+                val graph = DirectedGraph<Int>()
+                val v1 = graph.addVertex(1)
+                val v2 = graph.addVertex(2)
+                val v3 = graph.addVertex(3)
+                val v4 = graph.addVertex(4)
+                val v5 = graph.addVertex(5)
+
+                graph.addEdge(v1, v2)
+                graph.addEdge(v2, v3)
+                graph.addEdge(v3, v1)
+                graph.addEdge(v4, v3)
+                graph.addEdge(v4, v5)
+
+                val expectedValue = graph.getVertices()
+
+                graph.findSCC()
+
+                val actualValue = graph.getVertices()
+
+                assertEquals(expectedValue, actualValue)
+            }
+        }
     }
 }

--- a/app/src/test/kotlin/model/DirectedGraphTest.kt
+++ b/app/src/test/kotlin/model/DirectedGraphTest.kt
@@ -495,6 +495,95 @@ class DirectedGraphTest {
 
                 assertEquals(expectedValue, actualValue)
             }
+
+            @TestAllDirectedGraphs
+            fun `graph with nested cycles`() {
+                val graph = DirectedGraph<Int>()
+                val v1 = graph.addVertex(1)
+                val v2 = graph.addVertex(2)
+                val v3 = graph.addVertex(3)
+                val v4 = graph.addVertex(4)
+                val v5 = graph.addVertex(5)
+                val v6 = graph.addVertex(6)
+
+                graph.addEdge(v1, v2)
+                graph.addEdge(v2, v3)
+                graph.addEdge(v3, v1)
+                graph.addEdge(v3, v4)
+                graph.addEdge(v4, v5)
+                graph.addEdge(v5, v6)
+                graph.addEdge(v6, v4)
+
+                val actualValue = graph.findSCC()
+                val expectedValue = mutableSetOf(mutableSetOf(v1, v2, v3), mutableSetOf(v4, v5, v6))
+
+                assertEquals(expectedValue, actualValue)
+            }
+
+            @TestAllDirectedGraphs
+            fun `graph with cross connections`() {
+                val graph = DirectedGraph<Int>()
+                val v1 = graph.addVertex(1)
+                val v2 = graph.addVertex(2)
+                val v3 = graph.addVertex(3)
+                val v4 = graph.addVertex(4)
+                val v5 = graph.addVertex(5)
+                val v6 = graph.addVertex(6)
+
+                graph.addEdge(v1, v2)
+                graph.addEdge(v2, v3)
+                graph.addEdge(v3, v1)
+                graph.addEdge(v3, v4)
+                graph.addEdge(v4, v5)
+                graph.addEdge(v5, v6)
+                graph.addEdge(v6, v4)
+
+                val actualValue = graph.findSCC()
+                val expectedValue = mutableSetOf(mutableSetOf(v1, v2, v3), mutableSetOf(v4, v5, v6))
+
+                assertEquals(expectedValue, actualValue)
+            }
+
+            @TestAllDirectedGraphs
+            fun `graph with disconnected subgraphs`() {
+                val graph = DirectedGraph<Int>()
+                val v1 = graph.addVertex(1)
+                val v2 = graph.addVertex(2)
+                val v3 = graph.addVertex(3)
+                val v4 = graph.addVertex(4)
+                val v5 = graph.addVertex(5)
+                val v6 = graph.addVertex(6)
+
+                graph.addEdge(v1, v2)
+                graph.addEdge(v2, v1)
+                graph.addEdge(v3, v4)
+                graph.addEdge(v4, v3)
+                graph.addEdge(v5, v6)
+                graph.addEdge(v6, v5)
+
+                val actualValue = graph.findSCC()
+                val expectedValue = mutableSetOf(mutableSetOf(v1, v2), mutableSetOf(v3, v4), mutableSetOf(v5, v6))
+                assertEquals(expectedValue, actualValue)
+            }
+
+            @Disabled("Our model doesn't support edge from vertex to itself, check DirectedGraph.kt")
+            @TestAllDirectedGraphs
+            fun `graph with single vertex cycle`() {
+                val graph = DirectedGraph<Int>()
+                val v1 = graph.addVertex(1)
+                val v2 = graph.addVertex(2)
+                val v3 = graph.addVertex(3)
+
+                graph.addEdge(v1, v2)
+                graph.addEdge(v2, v3)
+                graph.addEdge(v3, v1)
+                graph.addEdge(v3, v3)
+
+                val actualValue = graph.findSCC()
+                val expectedValue = mutableSetOf(mutableSetOf(v1, v2, v3))
+
+                assertEquals(expectedValue, actualValue)
+            }
         }
 
         @Nested

--- a/app/src/test/kotlin/model/DirectedGraphTest.kt
+++ b/app/src/test/kotlin/model/DirectedGraphTest.kt
@@ -588,7 +588,6 @@ class DirectedGraphTest {
 
         @Nested
         inner class `SCC should return single-element SCCs`() {
-
             @TestAllDirectedGraphs
             fun `graph has single vertex`() {
                 val graph = DirectedGraph<Int>()
@@ -616,7 +615,6 @@ class DirectedGraphTest {
         }
         @Nested
         inner class `Additional edge cases`() {
-
             @TestAllDirectedGraphs
             fun `empty graph`() {
                 val graph = DirectedGraph<Int>()


### PR DESCRIPTION
#### Implement tests for Kosaraju's Strongly Connected Components search in directed (weighted&unweighted) graphs.

Btw, fix some arising issues:
- change return type of SCC algo from _ArrayList<ArrayList<Vertex<D>>>_ to _MutableSet<MutableSet<Vertex<D>>>_, due to inability of prediction SCC's position and position of vertices inside them.
- replace adjacency map iterations (to get all neighbours) to eponymous method _'getNeighbours'_

*Tests are written in DirectedGraph.kt, but execute on both (weighted&unweighted) varieties of it, by '_**@TestAllDirectedGraphs**_'. thx to @kar1mgh 