### PR TITLE
Implement algorithm for finding key vertices

### DIFF
--- a/app/src/main/kotlin/model/WeightedDirectedGraph.kt
+++ b/app/src/main/kotlin/model/WeightedDirectedGraph.kt
@@ -30,7 +30,7 @@ class WeightedDirectedGraph<D> : DirectedGraph<D>() {
     fun getWeight(edge: Edge<D>): Int {
         val weight = weightMap[edge]
             ?: throw NoSuchElementException(
-                "No weight found for edge between vertices (${edge.vertex1.id}, ${edge.vertex1.data})" +
+                "No weight found for edge between vertices (${edge.vertex1.id}, ${edge.vertex1.data}) " +
                     "and (${edge.vertex2.id}, ${edge.vertex2.data})"
             )
 

--- a/app/src/main/kotlin/model/WeightedDirectedGraph.kt
+++ b/app/src/main/kotlin/model/WeightedDirectedGraph.kt
@@ -30,12 +30,14 @@ class WeightedDirectedGraph<D> : DirectedGraph<D>() {
     fun getWeight(edge: Edge<D>): Int {
         val weight = weightMap[edge]
             ?: throw NoSuchElementException(
-                "No weight found for edge between vertices (${edge.vertex1.id}, ${edge.vertex1.data}) " +
+                "No weight found for edge between vertices (${edge.vertex1.id}, ${edge.vertex1.data})" +
                     "and (${edge.vertex2.id}, ${edge.vertex2.data})"
             )
 
         return weight
     }
+
+    override fun getWeightMap() = weightMap.toMap()
 
     fun findShortestPathDijkstra(srcVertex: Vertex<D>, destVertex: Vertex<D>): List<Pair<Vertex<D>, Edge<D>>>? {
         val distanceMap = mutableMapOf<Vertex<D>, Int>().withDefault { Int.MAX_VALUE }

--- a/app/src/main/kotlin/model/WeightedDirectedGraph.kt
+++ b/app/src/main/kotlin/model/WeightedDirectedGraph.kt
@@ -39,6 +39,12 @@ class WeightedDirectedGraph<D> : DirectedGraph<D>() {
 
     override fun getWeightMap() = weightMap.toMap()
 
+    override fun hasNegativeEdges(): Boolean {
+        val edgeWeighs = getWeightMap().values
+
+        return edgeWeighs.any { it < 0 }
+    }
+
     fun findShortestPathDijkstra(srcVertex: Vertex<D>, destVertex: Vertex<D>): List<Pair<Vertex<D>, Edge<D>>>? {
         val distanceMap = mutableMapOf<Vertex<D>, Int>().withDefault { Int.MAX_VALUE }
         val predecessorMap = mutableMapOf<Vertex<D>, Vertex<D>?>()

--- a/app/src/main/kotlin/model/WeightedUndirectedGraph.kt
+++ b/app/src/main/kotlin/model/WeightedUndirectedGraph.kt
@@ -31,7 +31,7 @@ class WeightedUndirectedGraph<D> : UndirectedGraph<D>() {
     fun getWeight(edge: Edge<D>): Int {
         val weight = weightMap[edge]
             ?: throw NoSuchElementException(
-                "No weight found for edge between vertices (${edge.vertex1.id}, ${edge.vertex1.data})" +
+                "No weight found for edge between vertices (${edge.vertex1.id}, ${edge.vertex1.data}) " +
                     "and (${edge.vertex2.id}, ${edge.vertex2.data})"
             )
 

--- a/app/src/main/kotlin/model/WeightedUndirectedGraph.kt
+++ b/app/src/main/kotlin/model/WeightedUndirectedGraph.kt
@@ -40,6 +40,12 @@ class WeightedUndirectedGraph<D> : UndirectedGraph<D>() {
 
     override fun getWeightMap() = weightMap.toMap()
 
+    override fun hasNegativeEdges(): Boolean {
+        val edgeWeighs = getWeightMap().values
+
+        return edgeWeighs.any { it < 0 }
+    }
+
     fun findShortestPathDijkstra(srcVertex: Vertex<D>, destVertex: Vertex<D>): List<Pair<Vertex<D>, Edge<D>>>? {
         val distanceMap = mutableMapOf<Vertex<D>, Int>().withDefault { Int.MAX_VALUE }
         val predecessorMap = mutableMapOf<Vertex<D>, Vertex<D>?>()

--- a/app/src/main/kotlin/model/WeightedUndirectedGraph.kt
+++ b/app/src/main/kotlin/model/WeightedUndirectedGraph.kt
@@ -31,12 +31,14 @@ class WeightedUndirectedGraph<D> : UndirectedGraph<D>() {
     fun getWeight(edge: Edge<D>): Int {
         val weight = weightMap[edge]
             ?: throw NoSuchElementException(
-                "No weight found for edge between vertices (${edge.vertex1.id}, ${edge.vertex1.data}) " +
+                "No weight found for edge between vertices (${edge.vertex1.id}, ${edge.vertex1.data})" +
                     "and (${edge.vertex2.id}, ${edge.vertex2.data})"
             )
 
         return weight
     }
+
+    override fun getWeightMap() = weightMap.toMap()
 
     fun findShortestPathDijkstra(srcVertex: Vertex<D>, destVertex: Vertex<D>): List<Pair<Vertex<D>, Edge<D>>>? {
         val distanceMap = mutableMapOf<Vertex<D>, Int>().withDefault { Int.MAX_VALUE }

--- a/app/src/main/kotlin/model/abstractGraph/Graph.kt
+++ b/app/src/main/kotlin/model/abstractGraph/Graph.kt
@@ -90,6 +90,8 @@ abstract class Graph<D> {
 
     abstract fun getEdge(vertex1: Vertex<D>, vertex2: Vertex<D>): Edge<D>
 
+    open fun hasNegativeEdges() = false
+
     /* For every vertex, calculates normalized closeness centrality, based on which the key vertices are picked.
      * Formula was taken from "Efficient Top-k Closeness Centrality Search" by Paul W. Olsen et al.,
      * yet an easier algorithm for traversal was chosen. */

--- a/app/src/main/kotlin/model/abstractGraph/Graph.kt
+++ b/app/src/main/kotlin/model/abstractGraph/Graph.kt
@@ -1,5 +1,10 @@
 package model.abstractGraph
 
+import java.util.*
+import java.util.ArrayDeque
+import kotlin.NoSuchElementException
+import kotlin.collections.ArrayList
+
 abstract class Graph<D> {
     protected val vertices: ArrayList<Vertex<D>> = arrayListOf()
     protected val edges: MutableSet<Edge<D>> = mutableSetOf()
@@ -83,4 +88,113 @@ abstract class Graph<D> {
     }
 
     abstract fun getEdge(vertex1: Vertex<D>, vertex2: Vertex<D>): Edge<D>
+
+
+    /* For every vertex, calculates normalized closeness centrality, based on which the key vertices are picked.
+     * Formula was taken from "Efficient Top-k Closeness Centrality Search" by Paul W. Olsen et al.,
+     * yet an easier algorithm for traversal was chosen. */
+    fun findKeyVertices(): Map<Vertex<D>, Double> {
+        val graphSize = vertices.size
+
+        val distanceMap = getWeightMap()
+        if (!distanceMap.values.all { it >= 0 })
+            throw IllegalArgumentException("Cannot run key vertices finding algorithm for graph with negative edges.")
+
+        val centralityMap = mutableMapOf<Vertex<D>, Double>()
+
+        for (currVertex in vertices) {
+            val currSumOfDistances = calcSumOfDistancesFromVertex(currVertex, distanceMap, graphSize)
+
+            val reachableNum = findReachableVerticesNumFromVertex(currVertex, graphSize)
+
+            val currCentrality = calcCentralityOfVertex(currSumOfDistances, reachableNum, graphSize)
+            centralityMap[currVertex] = currCentrality
+        }
+
+        return centralityMap
+    }
+
+    /* Uses modified Dijkstra's algorithm to calculate the sum of all weights (distances)
+     * of shortest paths from source vertex to every other reachable one */
+    private fun calcSumOfDistancesFromVertex(
+        srcVertex: Vertex<D>,
+        distanceMap: Map<Edge<D>, Int>,
+        graphSize: Int
+    ): Int {
+        val POS_INF = 100_000_000   // to infinity and beyond
+
+        val visited = Array(graphSize) { false }
+
+        val distances = Array(graphSize) { POS_INF }
+        distances[srcVertex.id] = 0
+
+        // stores pairs of vertices and total distances to them, sorted by distances ascending
+        val priorityQueue = PriorityQueue<Pair<Vertex<D>, Int>>(compareBy { it.second })
+        priorityQueue.add(srcVertex to distances[srcVertex.id])
+
+        while (priorityQueue.isNotEmpty()) {
+            val (currVertex, currDistance) = priorityQueue.poll()
+
+            if (visited[currVertex.id]) continue
+
+            visited[currVertex.id] = true
+
+            val neighbours = getNeighbours(currVertex)
+            for (neighbour in neighbours) {
+                val edgeToNeighbour = getEdge(currVertex, neighbour)
+
+                val edgeToNeighbourDistance = distanceMap[edgeToNeighbour] ?: POS_INF
+
+                val totalDistanceToNeighbour = currDistance + edgeToNeighbourDistance
+
+                if (totalDistanceToNeighbour < distances[neighbour.id]) {
+                    distances[neighbour.id] = totalDistanceToNeighbour
+                    priorityQueue.add(neighbour to totalDistanceToNeighbour)
+                }
+            }
+        }
+
+        for (i in distances.indices) {
+            if (distances[i] == POS_INF) distances[i] = 0
+        }
+
+        val sum = distances.sum()
+
+        return sum
+    }
+
+    private fun findReachableVerticesNumFromVertex(vertex: Vertex<D>, graphSize: Int): Int {
+        var reachableVerticesNum = 0
+
+        val verticesToVisit = ArrayDeque<Vertex<D>>()
+        verticesToVisit.add(vertex)
+
+        val visited = Array(graphSize) { false }
+
+        while (verticesToVisit.isNotEmpty()) {
+            val vertexToVisit = verticesToVisit.poll()
+
+            if (visited[vertexToVisit.id]) continue
+
+            for (neighbour in getNeighbours(vertexToVisit)) {
+                verticesToVisit.add(neighbour)
+            }
+
+            visited[vertexToVisit.id] = true
+            verticesToVisit.add(vertexToVisit)
+
+            reachableVerticesNum++
+        }
+
+        return reachableVerticesNum
+    }
+
+    private fun calcCentralityOfVertex(sumOfDistances: Int, reachableNum: Int, graphSize: Int): Double {
+        if (sumOfDistances == 0) return 0.0
+
+        val centrality =
+            ((reachableNum - 1) * (reachableNum - 1)) / ((graphSize - 1) * sumOfDistances).toDouble()
+
+        return centrality
+    }
 }

--- a/app/src/main/kotlin/model/abstractGraph/Graph.kt
+++ b/app/src/main/kotlin/model/abstractGraph/Graph.kt
@@ -58,6 +58,16 @@ abstract class Graph<D> {
 
     fun getVertices() = vertices.toList()
 
+    /* In undirected graph, returns a map with every edge as a key and 1 as a value
+     * In a directed graph, returns copy of weightMap property */
+    open fun getWeightMap(): Map<Edge<D>, Int> {
+        val weightMap = mutableMapOf<Edge<D>, Int>()
+
+        for (edge in edges) weightMap[edge] = 1
+
+        return weightMap
+    }
+
     fun getNeighbours(vertex: Vertex<D>): List<Vertex<D>> {
         val neighbours = adjacencyMap[vertex]
             ?: throw NoSuchElementException("Vertex (${vertex.id}, ${vertex.data}) isn't in the adjacency map.")

--- a/app/src/main/kotlin/model/abstractGraph/Graph.kt
+++ b/app/src/main/kotlin/model/abstractGraph/Graph.kt
@@ -4,6 +4,7 @@ import java.util.*
 import java.util.ArrayDeque
 import kotlin.NoSuchElementException
 import kotlin.collections.ArrayList
+import kotlin.math.roundToInt
 
 abstract class Graph<D> {
     protected val vertices: ArrayList<Vertex<D>> = arrayListOf()
@@ -89,11 +90,10 @@ abstract class Graph<D> {
 
     abstract fun getEdge(vertex1: Vertex<D>, vertex2: Vertex<D>): Edge<D>
 
-
     /* For every vertex, calculates normalized closeness centrality, based on which the key vertices are picked.
      * Formula was taken from "Efficient Top-k Closeness Centrality Search" by Paul W. Olsen et al.,
      * yet an easier algorithm for traversal was chosen. */
-    fun findKeyVertices(): Map<Vertex<D>, Double> {
+    fun findKeyVertices(): Set<Vertex<D>> {
         val graphSize = vertices.size
 
         val distanceMap = getWeightMap()
@@ -111,7 +111,9 @@ abstract class Graph<D> {
             centralityMap[currVertex] = currCentrality
         }
 
-        return centralityMap
+        val keyVertices = pickMostKeyVertices(centralityMap, graphSize)
+
+        return keyVertices
     }
 
     /* Uses modified Dijkstra's algorithm to calculate the sum of all weights (distances)
@@ -196,5 +198,26 @@ abstract class Graph<D> {
             ((reachableNum - 1) * (reachableNum - 1)) / ((graphSize - 1) * sumOfDistances).toDouble()
 
         return centrality
+    }
+
+    private fun pickMostKeyVertices(centralityMap: Map<Vertex<D>, Double>, graphSize: Int): Set<Vertex<D>> {
+        val keyVertices = mutableSetOf<Vertex<D>>()
+
+        val percent = 0.2
+        val keyVerticesNum = (graphSize * percent).roundToInt()     // rounds up
+
+        var currKeyVerticesNum = 0
+
+        val vertexCentralityPairs = centralityMap.toList()
+        val vertexCentralityPairsSorted = vertexCentralityPairs.sortedByDescending { it.second }
+
+        for ((vertex, _) in vertexCentralityPairsSorted) {
+            if (currKeyVerticesNum >= keyVerticesNum) break
+
+            keyVertices.add(vertex)
+            currKeyVerticesNum++
+        }
+
+        return keyVertices
     }
 }

--- a/app/src/main/kotlin/model/abstractGraph/Graph.kt
+++ b/app/src/main/kotlin/model/abstractGraph/Graph.kt
@@ -95,12 +95,11 @@ abstract class Graph<D> {
     /* For every vertex, calculates normalized closeness centrality, based on which the key vertices are picked.
      * Formula was taken from "Efficient Top-k Closeness Centrality Search" by Paul W. Olsen et al.,
      * yet an easier algorithm for traversal was chosen. */
-    fun findKeyVertices(): Set<Vertex<D>> {
+    fun findKeyVertices(): Set<Vertex<D>>? {
         val graphSize = vertices.size
 
         val distanceMap = getWeightMap()
-        if (!distanceMap.values.all { it >= 0 })
-            throw IllegalArgumentException("Cannot run key vertices finding algorithm for graph with negative edges.")
+        if (this.hasNegativeEdges()) return null
 
         val centralityMap = mutableMapOf<Vertex<D>, Double>()
 


### PR DESCRIPTION
**Implement `findKeyVertices()` method of abstract graph, which computes closeness centrality to find key vertices in any kind of graph.**

This method is based on the algorithm proposed in the book "Efficient Top-k Closeness Centrality Search" by Paul W. Olsen et al., and the formula of centrality is taken from there. I chose simple Dijkstra's algorithm for calculating the distances of paths. 

This algorithm doesn't work in graphs with negative edge weights, resulting in returning null.

To make this algorithm general for every graph, I needed to add `getWeightMap()` method, which returns:
- a copy of weightMap property, if graph is weighted
- a newly created map with every edge associated with weight 1, if graph is unweighted.
 
I also implemented `hasNegativeEdges()` method in every graph, which speaks for itself.