### PR TITLE
Implement tests for key vertices finding algorithm

### DIFF
--- a/app/src/test/kotlin/model/DirectedGraphTest.kt
+++ b/app/src/test/kotlin/model/DirectedGraphTest.kt
@@ -5,12 +5,10 @@ import model.abstractGraph.Vertex
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Nested
-import org.junit.jupiter.api.Test
 import util.annotations.TestAllDirectedGraphs
 import util.emptyEdgesSet
 import util.emptyVerticesList
 import util.setupAbstractGraph
-import util.setupGraphForFindingCycles
 
 class DirectedGraphTest {
     @Nested
@@ -463,10 +461,12 @@ class DirectedGraphTest {
                 val v3 = graph.addVertex(3)
                 val v4 = graph.addVertex(4)
 
-                graph.addEdge(v1, v2)
-                graph.addEdge(v2, v3)
-                graph.addEdge(v3, v1)
-                graph.addEdge(v3, v4)
+                graph.apply {
+                    addEdge(v1, v2)
+                    addEdge(v2, v3)
+                    addEdge(v3, v1)
+                    addEdge(v3, v4)
+                }
 
                 val actualValue = graph.findSCC()
                 val expectedValue = mutableSetOf(mutableSetOf(v1, v2, v3), mutableSetOf(v4))
@@ -482,11 +482,13 @@ class DirectedGraphTest {
                 val v4 = graph.addVertex(4)
                 val v5 = graph.addVertex(5)
 
-                graph.addEdge(v1, v2)
-                graph.addEdge(v2, v1)
-                graph.addEdge(v3, v4)
-                graph.addEdge(v4, v3)
-                graph.addEdge(v5, v1)
+                graph.apply {
+                    addEdge(v1, v2)
+                    addEdge(v2, v1)
+                    addEdge(v3, v4)
+                    addEdge(v4, v3)
+                    addEdge(v5, v1)
+                }
 
                 val actualValue = graph.findSCC()
                 val expectedValue = mutableSetOf(mutableSetOf(v3, v4), mutableSetOf(v1, v2), mutableSetOf(v5))
@@ -503,13 +505,15 @@ class DirectedGraphTest {
                 val v5 = graph.addVertex(5)
                 val v6 = graph.addVertex(6)
 
-                graph.addEdge(v1, v2)
-                graph.addEdge(v2, v3)
-                graph.addEdge(v3, v1)
-                graph.addEdge(v3, v4)
-                graph.addEdge(v4, v5)
-                graph.addEdge(v5, v6)
-                graph.addEdge(v6, v4)
+                graph.apply {
+                    addEdge(v1, v2)
+                    addEdge(v2, v3)
+                    addEdge(v3, v1)
+                    addEdge(v3, v4)
+                    addEdge(v4, v5)
+                    addEdge(v5, v6)
+                    addEdge(v6, v4)
+                }
 
                 val actualValue = graph.findSCC()
                 val expectedValue = mutableSetOf(mutableSetOf(v1, v2, v3), mutableSetOf(v4, v5, v6))
@@ -526,13 +530,15 @@ class DirectedGraphTest {
                 val v5 = graph.addVertex(5)
                 val v6 = graph.addVertex(6)
 
-                graph.addEdge(v1, v2)
-                graph.addEdge(v2, v3)
-                graph.addEdge(v3, v1)
-                graph.addEdge(v3, v4)
-                graph.addEdge(v4, v5)
-                graph.addEdge(v5, v6)
-                graph.addEdge(v6, v4)
+                graph.apply {
+                    addEdge(v1, v2)
+                    addEdge(v2, v3)
+                    addEdge(v3, v1)
+                    addEdge(v3, v4)
+                    addEdge(v4, v5)
+                    addEdge(v5, v6)
+                    addEdge(v6, v4)
+                }
 
                 val actualValue = graph.findSCC()
                 val expectedValue = mutableSetOf(mutableSetOf(v1, v2, v3), mutableSetOf(v4, v5, v6))
@@ -549,12 +555,14 @@ class DirectedGraphTest {
                 val v5 = graph.addVertex(5)
                 val v6 = graph.addVertex(6)
 
-                graph.addEdge(v1, v2)
-                graph.addEdge(v2, v1)
-                graph.addEdge(v3, v4)
-                graph.addEdge(v4, v3)
-                graph.addEdge(v5, v6)
-                graph.addEdge(v6, v5)
+                graph.apply {
+                    addEdge(v1, v2)
+                    addEdge(v2, v1)
+                    addEdge(v3, v4)
+                    addEdge(v4, v3)
+                    addEdge(v5, v6)
+                    addEdge(v6, v5)
+                }
 
                 val actualValue = graph.findSCC()
                 val expectedValue = mutableSetOf(mutableSetOf(v1, v2), mutableSetOf(v3, v4), mutableSetOf(v5, v6))
@@ -568,10 +576,12 @@ class DirectedGraphTest {
                 val v2 = graph.addVertex(2)
                 val v3 = graph.addVertex(3)
 
-                graph.addEdge(v1, v2)
-                graph.addEdge(v2, v3)
-                graph.addEdge(v3, v1)
-                graph.addEdge(v3, v3)
+                graph.apply {
+                    addEdge(v1, v2)
+                    addEdge(v2, v3)
+                    addEdge(v3, v1)
+                    addEdge(v3, v3)
+                }
 
                 val actualValue = graph.findSCC()
                 val expectedValue = mutableSetOf(mutableSetOf(v1, v2, v3))
@@ -600,7 +610,13 @@ class DirectedGraphTest {
                 val v4 = graph.addVertex(4)
 
                 val actualValue = graph.findSCC()
-                val expectedValue = mutableSetOf(mutableSetOf(v1), mutableSetOf(v2), mutableSetOf(v3), mutableSetOf(v4))
+                val expectedValue =
+                    mutableSetOf(
+                        mutableSetOf(v1),
+                        mutableSetOf(v2),
+                        mutableSetOf(v3),
+                        mutableSetOf(v4)
+                    )
 
                 assertEquals(expectedValue, actualValue)
             }
@@ -655,11 +671,13 @@ class DirectedGraphTest {
                 val v4 = graph.addVertex(4)
                 val v5 = graph.addVertex(5)
 
-                graph.addEdge(v1, v2)
-                graph.addEdge(v2, v3)
-                graph.addEdge(v3, v1)
-                graph.addEdge(v4, v3)
-                graph.addEdge(v4, v5)
+                graph.apply {
+                    addEdge(v1, v2)
+                    addEdge(v2, v3)
+                    addEdge(v3, v1)
+                    addEdge(v4, v3)
+                    addEdge(v4, v5)
+                }
 
                 val actualValue = graph.findSCC()
                 val expectedValue = mutableSetOf(mutableSetOf(v1, v2, v3), mutableSetOf(v4), mutableSetOf(v5))
@@ -677,12 +695,13 @@ class DirectedGraphTest {
                 val v3 = graph.addVertex(3)
                 val v4 = graph.addVertex(4)
 
-                graph.addEdge(v1, v2)
-                graph.addEdge(v2, v3)
-                graph.addEdge(v3, v1)
-                graph.addEdge(v3, v4)
+                graph.apply {
+                    addEdge(v1, v2)
+                    addEdge(v2, v3)
+                    addEdge(v3, v1)
+                    addEdge(v3, v4)
+                }
 
-                val edgesBeforeReverse = graph.getEdges()
                 val expectedValue = graph.getVertices()
                 graph.findSCC()
                 val actualValue = graph.getVertices()
@@ -697,16 +716,15 @@ class DirectedGraphTest {
                 val v3 = graph.addVertex(3)
                 val v4 = graph.addVertex(4)
 
-                graph.addEdge(v1, v2)
-                graph.addEdge(v2, v3)
-                graph.addEdge(v3, v1)
-                graph.addEdge(v3, v4)
-
+                graph.apply {
+                    addEdge(v1, v2)
+                    addEdge(v2, v3)
+                    addEdge(v3, v1)
+                    addEdge(v3, v4)
+                }
 
                 val expectedValue = graph.getEdges()
-
                 graph.findSCC()
-
                 val actualValue = graph.getEdges()
 
                 assertEquals(expectedValue, actualValue)
@@ -720,16 +738,16 @@ class DirectedGraphTest {
                 val v4 = graph.addVertex(4)
                 val v5 = graph.addVertex(5)
 
-                graph.addEdge(v1, v2)
-                graph.addEdge(v2, v3)
-                graph.addEdge(v3, v1)
-                graph.addEdge(v4, v3)
-                graph.addEdge(v4, v5)
+                graph.apply {
+                    addEdge(v1, v2)
+                    addEdge(v2, v3)
+                    addEdge(v3, v1)
+                    addEdge(v4, v3)
+                    addEdge(v4, v5)
+                }
 
                 val expectedValue = graph.getEdges()
-
                 graph.findSCC()
-
                 val actualValue = graph.getEdges()
 
                 assertEquals(expectedValue, actualValue)
@@ -743,16 +761,16 @@ class DirectedGraphTest {
                 val v4 = graph.addVertex(4)
                 val v5 = graph.addVertex(5)
 
-                graph.addEdge(v1, v2)
-                graph.addEdge(v2, v3)
-                graph.addEdge(v3, v1)
-                graph.addEdge(v4, v3)
-                graph.addEdge(v4, v5)
+                graph.apply {
+                    addEdge(v1, v2)
+                    addEdge(v2, v3)
+                    addEdge(v3, v1)
+                    addEdge(v4, v3)
+                    addEdge(v4, v5)
+                }
 
                 val expectedValue = graph.getVertices()
-
                 graph.findSCC()
-
                 val actualValue = graph.getVertices()
 
                 assertEquals(expectedValue, actualValue)
@@ -837,47 +855,21 @@ class DirectedGraphTest {
                 val e78 = graph.addEdge(v7, v8)
                 val e87 = graph.addEdge(v8, v7)
 
-                val expectedCycle1 = listOf(
-                    e12 to v2,
-                    e21 to v1
-                )
-
-                val expectedCycle2 = listOf(
-                    e12 to v2,
-                    e20 to v0,
-                    e01 to v1
-                )
-
-                val expectedCycle3 = listOf(
-                    e12 to v2,
-                    e20 to v0,
-                    e04 to v4,
-                    e41 to v1
-                )
-
-                val expectedCycle4 = listOf(
-                    e12 to v2,
-                    e23 to v3,
-                    e34 to v4,
-                    e41 to v1
-                )
-
-                val expectedCycle5 = listOf(
-                    e12 to v2,
-                    e25 to v5,
-                    e53 to v3,
-                    e34 to v4,
-                    e41 to v1
-                )
+                val expectedCycle1 = listOf(e12 to v2, e21 to v1)
+                val expectedCycle2 = listOf(e12 to v2, e20 to v0, e01 to v1)
+                val expectedCycle3 = listOf(e12 to v2, e20 to v0, e04 to v4, e41 to v1)
+                val expectedCycle4 = listOf(e12 to v2, e23 to v3, e34 to v4, e41 to v1)
+                val expectedCycle5 = listOf(e12 to v2, e25 to v5, e53 to v3, e34 to v4, e41 to v1)
 
                 val actualValue = graph.findCycles(v1)
-                val expectedValue = setOf(
-                    expectedCycle1,
-                    expectedCycle2,
-                    expectedCycle3,
-                    expectedCycle4,
-                    expectedCycle5
-                )
+                val expectedValue =
+                    setOf(
+                        expectedCycle1,
+                        expectedCycle2,
+                        expectedCycle3,
+                        expectedCycle4,
+                        expectedCycle5
+                    )
 
                 assertEquals(expectedValue, actualValue)
             }
@@ -895,12 +887,7 @@ class DirectedGraphTest {
                 val e23 = graph.addEdge(v2, v3)
 
                 val actualValue = graph.findCycles(v1)
-                val expectedValue = setOf(
-                    listOf(
-                        e12 to v2,
-                        e21 to v1
-                    )
-                )
+                val expectedValue = setOf(listOf(e12 to v2, e21 to v1))
 
                 assertEquals(expectedValue, actualValue)
             }
@@ -913,7 +900,7 @@ class DirectedGraphTest {
                 val v0 = graph.addVertex(0)
                 val v1 = graph.addVertex(1)
 
-                val e01 = graph.addEdge(v0, v1)
+                graph.addEdge(v0, v1)
 
                 val actualValue = graph.findCycles(v1)
                 val expectedValue = emptySet<List<Pair<Edge<Int>, Vertex<Int>>>>()
@@ -926,7 +913,7 @@ class DirectedGraphTest {
                 val v0 = graph.addVertex(0)
                 val v1 = graph.addVertex(1)
 
-                val e01 = graph.addEdge(v0, v1)
+                graph.addEdge(v0, v1)
 
                 val actualValue = graph.findCycles(v0)
                 val expectedValue = emptySet<List<Pair<Edge<Int>, Vertex<Int>>>>()
@@ -940,13 +927,11 @@ class DirectedGraphTest {
             val v0 = graph.addVertex(0)
             val v1 = graph.addVertex(1)
 
-            val e01 = graph.addEdge(v0, v1)
-            val e10 = graph.addEdge(v1, v0)
+            graph.addEdge(v0, v1)
+            graph.addEdge(v1, v0)
 
             val expectedGraph = graph.getVertices() to graph.getEdges().toSet()
-
             graph.findCycles(v1)
-
             val actualGraph = graph.getVertices() to graph.getEdges().toSet()
 
             assertEquals(expectedGraph, actualGraph)

--- a/app/src/test/kotlin/model/DirectedGraphTest.kt
+++ b/app/src/test/kotlin/model/DirectedGraphTest.kt
@@ -5,6 +5,7 @@ import model.abstractGraph.Vertex
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 import util.annotations.TestAllDirectedGraphs
 import util.emptyEdgesSet
 import util.emptyVerticesList
@@ -759,14 +760,52 @@ class DirectedGraphTest {
         }
     }
 
-//    [[(model.abstractGraph.Edge@1acaf3d, model.abstractGraph.Vertex@27e47833), (model.abstractGraph.Edge@1bab8268, model.abstractGraph.Vertex@44a59da3)],
-//    [(model.abstractGraph.Edge@1acaf3d, model.abstractGraph.Vertex@27e47833), (model.abstractGraph.Edge@6986852, model.abstractGraph.Vertex@42a15bdc), (model.abstractGraph.Edge@704deff2, model.abstractGraph.Vertex@44a59da3)],
-//    [(model.abstractGraph.Edge@1acaf3d, model.abstractGraph.Vertex@27e47833), (model.abstractGraph.Edge@6986852, model.abstractGraph.Vertex@42a15bdc), (model.abstractGraph.Edge@404bbcbd, model.abstractGraph.Vertex@27508c5d), (model.abstractGraph.Edge@658c5a19, model.abstractGraph.Vertex@44a59da3)],
-//    [(model.abstractGraph.Edge@1acaf3d, model.abstractGraph.Vertex@27e47833), (model.abstractGraph.Edge@6e01f9b0, model.abstractGraph.Vertex@6f6745d6), (model.abstractGraph.Edge@6c61a903, model.abstractGraph.Vertex@27508c5d), (model.abstractGraph.Edge@658c5a19, model.abstractGraph.Vertex@44a59da3)],
-//    [(model.abstractGraph.Edge@1acaf3d, model.abstractGraph.Vertex@27e47833), (model.abstractGraph.Edge@a307a8c, model.abstractGraph.Vertex@4f704591), (model.abstractGraph.Edge@2b9ed6da, model.abstractGraph.Vertex@6f6745d6), (model.abstractGraph.Edge@6c61a903, model.abstractGraph.Vertex@27508c5d), (model.abstractGraph.Edge@658c5a19, model.abstractGraph.Vertex@44a59da3)]]
+    @Nested
+    inner class FindKeyVerticesTest {
+        @Nested
+        inner class `One vertex is picked over another`() {
+            @TestAllDirectedGraphs
+            fun `if it can reach more vertices`(graph: DirectedGraph<Int>) {
+                val v0 = graph.addVertex(0)
+                val v1 = graph.addVertex(1)
+                val v2 = graph.addVertex(2)
+                val v3 = graph.addVertex(3)
 
+                graph.apply {
+                    addEdge(v0, v1)
+                    addEdge(v0, v2)
+                    addEdge(v0, v3)
+                    addEdge(v1, v2)
+                }
 
-//    [[(model.abstractGraph.Edge@1acaf3d, model.abstractGraph.Vertex@27e47833), (model.abstractGraph.Edge@6986852, model.abstractGraph.Vertex@42a15bdc), (model.abstractGraph.Edge@704deff2, model.abstractGraph.Vertex@44a59da3)], [(model.abstractGraph.Edge@1acaf3d, model.abstractGraph.Vertex@27e47833), (model.abstractGraph.Edge@1bab8268, model.abstractGraph.Vertex@44a59da3)]]
+                val expectedResult = setOf(v0)
+                val actualResult = graph.findKeyVertices()
+
+                assertEquals(expectedResult, actualResult)
+            }
+
+            @TestAllDirectedGraphs
+            fun `if it can reach other vertices with fewer edges`(graph: DirectedGraph<Int>) {
+                val v0 = graph.addVertex(0)
+                val v1 = graph.addVertex(1)
+                val v2 = graph.addVertex(2)
+                val v3 = graph.addVertex(3)
+
+                graph.apply {
+                    addEdge(v1, v2)
+                    addEdge(v2, v3)
+                    addEdge(v0, v2)
+                    addEdge(v0, v3)
+                }
+
+                val expectedResult = setOf(v0)
+                val actualResult = graph.findKeyVertices()
+
+                assertEquals(expectedResult, actualResult)
+            }
+        }
+    }
+
     @Nested
     inner class FindCyclesTest {
         @Nested

--- a/app/src/test/kotlin/model/UndirectedGraphTest.kt
+++ b/app/src/test/kotlin/model/UndirectedGraphTest.kt
@@ -5,7 +5,6 @@ import model.abstractGraph.Vertex
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Nested
-import util.annotations.TestAllDirectedGraphs
 import util.annotations.TestAllUndirectedGraphs
 import util.setupAbstractGraph
 
@@ -133,11 +132,7 @@ class UndirectedGraphTest {
                 val v4 = defaultVerticesList[4]
 
                 val actualValue = graph.getOutgoingEdges(v3).toSet()
-                val expectedValue = setOf(
-                    graph.getEdge(v3, v4),
-                    graph.getEdge(v3, v1),
-                    graph.getEdge(v3, v2)
-                )
+                val expectedValue = setOf(graph.getEdge(v3, v4), graph.getEdge(v3, v1), graph.getEdge(v3, v2))
 
                 assertEquals(expectedValue, actualValue)
             }
@@ -246,13 +241,13 @@ class UndirectedGraphTest {
                     val expectedEdges1 = setOf(graph.getEdge(v0, v1), graph.getEdge(v0, v3))
 
                     val actualEdges2 = graph.getOutgoingEdges(v3).toSet()
-                    val expectedEdges2 = setOf(
-                        graph.getEdge(v3, v0),
-                        graph.getEdge(v3, v1),
-                        graph.getEdge(v3, v2),
-                        graph.getEdge(v3, v4)
-                    )
-
+                    val expectedEdges2 =
+                        setOf(
+                            graph.getEdge(v3, v0),
+                            graph.getEdge(v3, v1),
+                            graph.getEdge(v3, v2),
+                            graph.getEdge(v3, v4)
+                        )
 
                     assertEquals(expectedEdges1, actualEdges1)
                     assertEquals(expectedEdges2, actualEdges2)
@@ -515,11 +510,12 @@ class UndirectedGraphTest {
                 graph.removeEdge(edgeToRemove)
 
                 val actualEdges1 = graph.getOutgoingEdges(v1).toSet()
-                val expectedEdges1 = setOf(
-                    graph.getEdge(v1, v0),
-                    graph.getEdge(v1, v3),
-                    graph.getEdge(v1, v4),
-                )
+                val expectedEdges1 =
+                    setOf(
+                        graph.getEdge(v1, v0),
+                        graph.getEdge(v1, v3),
+                        graph.getEdge(v1, v4),
+                    )
 
                 val actualEdges2 = graph.getOutgoingEdges(v2).toSet()
                 val expectedEdges2 = setOf(graph.getEdge(v2, v3))
@@ -534,7 +530,7 @@ class UndirectedGraphTest {
             @TestAllUndirectedGraphs
             fun `non-existing edge should throw an exception`(graph: UndirectedGraph<Int>) {
                 assertThrows(NoSuchElementException::class.java) {
-                    graph.removeEdge(Edge(Vertex(0,0), Vertex(1, 1)))
+                    graph.removeEdge(Edge(Vertex(0, 0), Vertex(1, 1)))
                 }
             }
         }

--- a/app/src/test/kotlin/model/UndirectedGraphTest.kt
+++ b/app/src/test/kotlin/model/UndirectedGraphTest.kt
@@ -5,6 +5,7 @@ import model.abstractGraph.Vertex
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Nested
+import util.annotations.TestAllDirectedGraphs
 import util.annotations.TestAllUndirectedGraphs
 import util.setupAbstractGraph
 
@@ -688,6 +689,31 @@ class UndirectedGraphTest {
                 val actualBridges = graph.findBridges()
 
                 assertEquals(expectedBridges, actualBridges)
+            }
+        }
+    }
+
+    @Nested
+    inner class FindKeyVerticesTest {
+        @Nested
+        inner class `One vertex is picked over another`() {
+            @TestAllUndirectedGraphs
+            fun `if it can reach other vertices with fewer edges`(graph: UndirectedGraph<Int>) {
+                val v0 = graph.addVertex(0)
+                val v1 = graph.addVertex(1)
+                val v2 = graph.addVertex(2)
+                val v3 = graph.addVertex(3)
+
+                graph.apply {
+                    addEdge(v0, v1)
+                    addEdge(v0, v2)
+                    addEdge(v0, v3)
+                }
+
+                val expectedResult = setOf(v0)
+                val actualResult = graph.findKeyVertices()
+
+                assertEquals(expectedResult, actualResult)
             }
         }
     }

--- a/app/src/test/kotlin/model/WeightedDirectedGraphTest.kt
+++ b/app/src/test/kotlin/model/WeightedDirectedGraphTest.kt
@@ -4,6 +4,7 @@ import model.abstractGraph.Edge
 import model.abstractGraph.Vertex
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Assertions.*
+import util.annotations.TestAllDirectedGraphs
 import util.setupDirectedGraphWithCycle
 import util.setupWeightedDirected
 
@@ -307,9 +308,96 @@ class WeightedDirectedGraphTest {
     }
 
     @Nested
+    inner class FindKeyVerticesTest {
+        @Nested
+        inner class `One vertex is picked over another`() {
+            @Test
+            fun `if it can reach more vertices`() {
+                val v0 = graph.addVertex(0)
+                val v1 = graph.addVertex(1)
+                val v2 = graph.addVertex(2)
+                val v3 = graph.addVertex(3)
+
+                graph.apply {
+                    addEdge(v0, v1, 1)
+                    addEdge(v0, v2, 1)
+                    addEdge(v0, v3, 1)
+                    addEdge(v1, v2, 1)
+                }
+
+                val expectedResult = setOf(v0)
+                val actualResult = graph.findKeyVertices()
+
+                assertEquals(expectedResult, actualResult)
+            }
+
+            @Test
+            fun `if it can reach other vertices with fewer edges`() {
+                val v0 = graph.addVertex(0)
+                val v1 = graph.addVertex(1)
+                val v2 = graph.addVertex(2)
+                val v3 = graph.addVertex(3)
+
+                graph.apply {
+                    addEdge(v0, v2, 1)
+                    addEdge(v0, v3, 1)
+                    addEdge(v1, v2, 1)
+                    addEdge(v2, v3, 1)
+                }
+
+                val expectedResult = setOf(v0)
+                val actualResult = graph.findKeyVertices()
+
+                assertEquals(expectedResult, actualResult)
+            }
+
+            @Test
+            fun `if its sum of distances to other vertices is less`() {
+                val v0 = graph.addVertex(0)
+                val v1 = graph.addVertex(1)
+                val v2 = graph.addVertex(2)
+                val v3 = graph.addVertex(3)
+
+                graph.apply {
+                    addEdge(v0, v2, 1)
+                    addEdge(v0, v3, 1)
+                    addEdge(v1, v2, 2)
+                    addEdge(v2, v3, 2)
+                }
+
+                val expectedResult = setOf(v0)
+                val actualResult = graph.findKeyVertices()
+
+                assertEquals(expectedResult, actualResult)
+            }
+        }
+
+        @Nested
+        inner class `Returns null`() {
+            @Test
+            fun `if graph has negative edges`() {
+                val v0 = graph.addVertex(0)
+                val v1 = graph.addVertex(1)
+                val v2 = graph.addVertex(2)
+
+                graph.apply {
+                    addEdge(v0, v1, 1)
+                    addEdge(v0, v2, -1)
+                }
+
+                val actualResult = graph.findKeyVertices()
+
+                assertNull(actualResult)
+            }
+        }
+    }
+
+    @Nested
     inner class findShortestPathFordBellmanTest {
+
         @Nested
         inner class `Path exists` {
+
             @Test
             fun `path between neighbours should consist of one edge`() {
                 val v0 = graph.addVertex(0)
@@ -351,7 +439,6 @@ class WeightedDirectedGraphTest {
 
                 assertEquals(expectedValue, actualValue)
             }
-
             @Test
             fun `graph shouldn't change`() {
                 val graphStructure = setupDirectedGraphWithCycle(graph)
@@ -372,6 +459,7 @@ class WeightedDirectedGraphTest {
 
         @Nested
         inner class `Path doesn't exist` {
+
             @Test
             fun `there is simply no path between vertices`() {
                 val graphStructure = setupDirectedGraphWithCycle(graph)
@@ -452,7 +540,6 @@ class WeightedDirectedGraphTest {
                 assertEquals(null, graph.findShortestPathFordBellman(v8, v6))
                 assertEquals(null, graph.findShortestPathFordBellman(v8, v7))
             }
-
             @Test
             fun `graph shouldn't change`() {
                 val graphStructure = setupDirectedGraphWithCycle(graph)

--- a/app/src/test/kotlin/model/WeightedDirectedGraphTest.kt
+++ b/app/src/test/kotlin/model/WeightedDirectedGraphTest.kt
@@ -4,7 +4,6 @@ import model.abstractGraph.Edge
 import model.abstractGraph.Vertex
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Assertions.*
-import util.annotations.TestAllDirectedGraphs
 import util.setupDirectedGraphWithCycle
 import util.setupWeightedDirected
 
@@ -95,9 +94,7 @@ class WeightedDirectedGraphTest {
 
             graph.removeEdge(edge)
 
-            assertThrows(NoSuchElementException::class.java) {
-                graph.getWeight(edge)
-            }
+            assertThrows(NoSuchElementException::class.java) { graph.getWeight(edge) }
         }
     }
 
@@ -160,7 +157,7 @@ class WeightedDirectedGraphTest {
 
                 val actualResult = graph.findShortestPathDijkstra(v0, v3)
 
-                Assertions.assertTrue(actualResult == expectedResult1 || actualResult == expectedResult2)
+                assertTrue(actualResult == expectedResult1 || actualResult == expectedResult2)
             }
 
             @Test
@@ -212,7 +209,7 @@ class WeightedDirectedGraphTest {
                 val expectedResult2 = listOf(e1 to v2, e3 to v3, e4 to v4)
                 val actualResult = graph.findShortestPathDijkstra(v0, v4)
 
-                Assertions.assertTrue(actualResult == expectedResult1 || actualResult == expectedResult2)
+                assertTrue(actualResult == expectedResult1 || actualResult == expectedResult2)
             }
 
             @Test
@@ -250,7 +247,6 @@ class WeightedDirectedGraphTest {
 
         @Nested
         inner class `No path should be returned`() {
-
             @Test
             fun `no path exists in directed graph`() {
                 val graph = WeightedDirectedGraph<Int>()
@@ -272,9 +268,11 @@ class WeightedDirectedGraphTest {
                 val v1 = graph.addVertex(1)
                 val v2 = graph.addVertex(2)
 
-                graph.addEdge(v0, v1, 1)
-                graph.addEdge(v1, v2, 2)
-                graph.addEdge(v2, v0, 2)
+                graph.apply {
+                    addEdge(v0, v1, 1)
+                    addEdge(v1, v2, 2)
+                    addEdge(v2, v0, 2)
+                }
 
                 val actualResult = graph.findShortestPathDijkstra(v0, v0)
 
@@ -297,8 +295,8 @@ class WeightedDirectedGraphTest {
                 val v1 = graph.addVertex(1)
                 val v2 = graph.addVertex(2)
 
-                val e0 = graph.addEdge(v0, v1, 0)
-                val e1 = graph.addEdge(v1, v2, 0)
+                graph.addEdge(v0, v1, 0)
+                graph.addEdge(v1, v2, 0)
 
                 val actualResult = graph.findShortestPathDijkstra(v2, v0)
 
@@ -380,10 +378,8 @@ class WeightedDirectedGraphTest {
                 val v1 = graph.addVertex(1)
                 val v2 = graph.addVertex(2)
 
-                graph.apply {
-                    addEdge(v0, v1, 1)
-                    addEdge(v0, v2, -1)
-                }
+                graph.addEdge(v0, v1, 1)
+                graph.addEdge(v0, v2, -1)
 
                 val actualResult = graph.findKeyVertices()
 
@@ -394,10 +390,8 @@ class WeightedDirectedGraphTest {
 
     @Nested
     inner class findShortestPathFordBellmanTest {
-
         @Nested
         inner class `Path exists` {
-
             @Test
             fun `path between neighbours should consist of one edge`() {
                 val v0 = graph.addVertex(0)
@@ -421,11 +415,12 @@ class WeightedDirectedGraphTest {
                 val v4 = defaultVertices[4]
 
                 val actualValue = graph.findShortestPathFordBellman(v0, v4)
-                val expectedValue = listOf(
-                    graph.getEdge(v0, v1) to v1,
-                    graph.getEdge(v1, v2) to v2,
-                    graph.getEdge(v2, v4) to v4
-                )
+                val expectedValue =
+                    listOf(
+                        graph.getEdge(v0, v1) to v1,
+                        graph.getEdge(v1, v2) to v2,
+                        graph.getEdge(v2, v4) to v4
+                    )
 
                 assertEquals(expectedValue, actualValue)
             }
@@ -439,6 +434,7 @@ class WeightedDirectedGraphTest {
 
                 assertEquals(expectedValue, actualValue)
             }
+
             @Test
             fun `graph shouldn't change`() {
                 val graphStructure = setupDirectedGraphWithCycle(graph)
@@ -448,9 +444,7 @@ class WeightedDirectedGraphTest {
                 val v4 = defaultVertices[4]
 
                 val expectedGraph = graphStructure
-
                 graph.findShortestPathFordBellman(v3, v4)
-
                 val actualGraph = graphStructure
 
                 assertEquals(expectedGraph, actualGraph)
@@ -459,7 +453,6 @@ class WeightedDirectedGraphTest {
 
         @Nested
         inner class `Path doesn't exist` {
-
             @Test
             fun `there is simply no path between vertices`() {
                 val graphStructure = setupDirectedGraphWithCycle(graph)
@@ -469,9 +462,8 @@ class WeightedDirectedGraphTest {
                 val v5 = defaultVertices[5]
 
                 val actualValue = graph.findShortestPathFordBellman(v1, v5)
-                val expectedValue = null
 
-                assertEquals(expectedValue, actualValue)
+                assertNull(actualValue)
             }
 
             @Test
@@ -483,9 +475,8 @@ class WeightedDirectedGraphTest {
                 val v2 = defaultVertices[2]
 
                 val actualValue = graph.findShortestPathFordBellman(v2, v0)
-                val expectedValue = null
 
-                assertEquals(expectedValue, actualValue)
+                assertNull(actualValue)
             }
 
             @Test
@@ -497,9 +488,8 @@ class WeightedDirectedGraphTest {
                 val v8 = defaultVertices[8]
 
                 val actualValue = graph.findShortestPathFordBellman(v0, v8)
-                val expectedValue = null
 
-                assertEquals(expectedValue, actualValue)
+                assertNull(actualValue)
             }
 
             @Test
@@ -511,9 +501,8 @@ class WeightedDirectedGraphTest {
                 val v8 = defaultVertices[8]
 
                 val actualValue = graph.findShortestPathFordBellman(v6, v8)
-                val expectedValue = null
 
-                assertEquals(expectedValue, actualValue)
+                assertNull(actualValue)
             }
 
             @Test
@@ -531,15 +520,16 @@ class WeightedDirectedGraphTest {
                 val v7 = defaultVertices[7]
                 val v8 = defaultVertices[8]
 
-                assertEquals(null, graph.findShortestPathFordBellman(v8, v0))
-                assertEquals(null, graph.findShortestPathFordBellman(v8, v1))
-                assertEquals(null, graph.findShortestPathFordBellman(v8, v2))
-                assertEquals(null, graph.findShortestPathFordBellman(v8, v3))
-                assertEquals(null, graph.findShortestPathFordBellman(v8, v4))
-                assertEquals(null, graph.findShortestPathFordBellman(v8, v5))
-                assertEquals(null, graph.findShortestPathFordBellman(v8, v6))
-                assertEquals(null, graph.findShortestPathFordBellman(v8, v7))
+                assertNull(graph.findShortestPathFordBellman(v8, v0))
+                assertNull(graph.findShortestPathFordBellman(v8, v1))
+                assertNull(graph.findShortestPathFordBellman(v8, v2))
+                assertNull(graph.findShortestPathFordBellman(v8, v3))
+                assertNull(graph.findShortestPathFordBellman(v8, v4))
+                assertNull(graph.findShortestPathFordBellman(v8, v5))
+                assertNull(graph.findShortestPathFordBellman(v8, v6))
+                assertNull(graph.findShortestPathFordBellman(v8, v7))
             }
+
             @Test
             fun `graph shouldn't change`() {
                 val graphStructure = setupDirectedGraphWithCycle(graph)
@@ -549,9 +539,7 @@ class WeightedDirectedGraphTest {
                 val v8 = defaultVertices[8]
 
                 val expectedGraph = graphStructure
-
                 graph.findShortestPathFordBellman(v8, v1)
-
                 val actualGraph = graphStructure
 
                 assertEquals(expectedGraph, actualGraph)

--- a/app/src/test/kotlin/model/WeightedUndirectedGraphTest.kt
+++ b/app/src/test/kotlin/model/WeightedUndirectedGraphTest.kt
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import util.annotations.TestAllDirectedGraphs
+import util.annotations.TestAllUndirectedGraphs
 import util.setupWeightedUndirected
 
 class WeightedUndirectedGraphTest {
@@ -419,6 +421,90 @@ class WeightedUndirectedGraphTest {
                 val actualResult = graph.findMinSpanningTree()
 
                 assertEquals(expectedResult, actualResult)
+            }
+        }
+    }
+
+    @Nested
+    inner class FindKeyVerticesTest {
+        @Nested
+        inner class `One vertex is picked over another`() {
+            @Test
+            fun `if it can reach more vertices`() {
+                val v0 = graph.addVertex(0)
+                val v1 = graph.addVertex(1)
+                val v2 = graph.addVertex(2)
+                val v3 = graph.addVertex(3)
+
+                graph.apply {
+                    addEdge(v0, v1, 1)
+                    addEdge(v0, v2, 1)
+                    addEdge(v0, v3, 1)
+                    addEdge(v1, v2, 1)
+                }
+
+                val expectedResult = setOf(v0)
+                val actualResult = graph.findKeyVertices()
+
+                assertEquals(expectedResult, actualResult)
+            }
+
+            @Test
+            fun `if it can reach other vertices with fewer edges`() {
+                val v0 = graph.addVertex(0)
+                val v1 = graph.addVertex(1)
+                val v2 = graph.addVertex(2)
+                val v3 = graph.addVertex(3)
+
+                graph.apply {
+                    addEdge(v0, v1)
+                    addEdge(v0, v2)
+                    addEdge(v0, v3)
+                }
+
+                val expectedResult = setOf(v0)
+                val actualResult = graph.findKeyVertices()
+
+                assertEquals(expectedResult, actualResult)
+            }
+
+            @Test
+            fun `if its sum of distances to other vertices is less`() {
+                val v0 = graph.addVertex(0)
+                val v1 = graph.addVertex(1)
+                val v2 = graph.addVertex(2)
+                val v3 = graph.addVertex(3)
+
+                graph.apply {
+                    addEdge(v0, v2, 1)
+                    addEdge(v0, v3, 1)
+                    addEdge(v1, v2, 2)
+                    addEdge(v2, v3, 2)
+                }
+
+                val expectedResult = setOf(v0)
+                val actualResult = graph.findKeyVertices()
+
+                assertEquals(expectedResult, actualResult)
+            }
+        }
+
+        @Nested
+        inner class `Returns null`() {
+            @Test
+            fun `if graph has negative edges`() {
+                val v0 = graph.addVertex(0)
+                val v1 = graph.addVertex(1)
+                val v2 = graph.addVertex(2)
+
+                graph.apply {
+                    addEdge(v0, v1, 1)
+                    addEdge(v0, v2, -1)
+                }
+
+                val actualResult = graph.findKeyVertices()
+
+                assertNull(actualResult)
             }
         }
     }

--- a/app/src/test/kotlin/model/WeightedUndirectedGraphTest.kt
+++ b/app/src/test/kotlin/model/WeightedUndirectedGraphTest.kt
@@ -7,8 +7,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import util.annotations.TestAllDirectedGraphs
-import util.annotations.TestAllUndirectedGraphs
 import util.setupWeightedUndirected
 
 class WeightedUndirectedGraphTest {
@@ -266,7 +264,7 @@ class WeightedUndirectedGraphTest {
 
                 val actualResult = graph.findShortestPathDijkstra(v0, v3)
 
-                assertEquals(actualResult, null)
+                assertNull(actualResult)
             }
 
             @Test
@@ -303,10 +301,10 @@ class WeightedUndirectedGraphTest {
                 val v0 = graph.addVertex(0)
                 val v1 = graph.addVertex(1)
 
-                graph.addEdge(v0, v1, 5)
-                val lightEdge = graph.addEdge(v0, v1, 3)
+                val e01Heavy = graph.addEdge(v0, v1, 5)
+                val e01Light = graph.addEdge(v0, v1, 3)
 
-                val expectedReturn = listOf(lightEdge)
+                val expectedReturn = listOf(e01Light)
                 val actualReturn = graph.findMinSpanningTree()
 
                 assertEquals(expectedReturn, actualReturn)
@@ -317,10 +315,10 @@ class WeightedUndirectedGraphTest {
                 val v0 = graph.addVertex(0)
                 val v1 = graph.addVertex(1)
 
-                graph.addEdge(v0, v1, -5)
-                val lightEdge = graph.addEdge(v0, v1, -10)
+                val e01Heavy = graph.addEdge(v0, v1, -5)
+                val e01Light = graph.addEdge(v0, v1, -10)
 
-                val expectedReturn = listOf(lightEdge)
+                val expectedReturn = listOf(e01Light)
                 val actualReturn = graph.findMinSpanningTree()
 
                 assertEquals(expectedReturn, actualReturn)
@@ -331,10 +329,10 @@ class WeightedUndirectedGraphTest {
                 val v0 = graph.addVertex(0)
                 val v1 = graph.addVertex(1)
 
-                graph.addEdge(v0, v1, 5)
-                val zeroEdge = graph.addEdge(v0, v1, 0)
+                val e01Pos = graph.addEdge(v0, v1, 5)
+                val e01Zero = graph.addEdge(v0, v1, 0)
 
-                val expectedReturn = listOf(zeroEdge)
+                val expectedReturn = listOf(e01Zero)
                 val actualReturn = graph.findMinSpanningTree()
 
                 assertEquals(expectedReturn, actualReturn)
@@ -345,11 +343,11 @@ class WeightedUndirectedGraphTest {
                 val v0 = graph.addVertex(0)
                 val v1 = graph.addVertex(1)
 
-                graph.addEdge(v0, v1, 5)
-                graph.addEdge(v0, v1, 0)
-                val negativeEdge = graph.addEdge(v0, v1, -5)
+                val e01Pos = graph.addEdge(v0, v1, 5)
+                val e01Zero = graph.addEdge(v0, v1, 0)
+                val e01Neg = graph.addEdge(v0, v1, -5)
 
-                val expectedReturn = listOf(negativeEdge)
+                val expectedReturn = listOf(e01Neg)
                 val actualReturn = graph.findMinSpanningTree()
 
                 assertEquals(expectedReturn, actualReturn)
@@ -369,7 +367,7 @@ class WeightedUndirectedGraphTest {
                 val e12 = graph.addEdge(v1, v2, 1)
                 val e23 = graph.addEdge(v2, v3, 1)
 
-                val cycleEdge30 = graph.addEdge(v3, v0, 5)
+                val e30 = graph.addEdge(v3, v0, 5)
 
                 val expectedReturn = setOf(e01, e12, e23)
                 val actualReturn = graph.findMinSpanningTree().toSet()
@@ -388,12 +386,12 @@ class WeightedUndirectedGraphTest {
                 val v3 = graph.addVertex(3)
                 val v4 = graph.addVertex(4)
 
-                val e01 = graph.addEdge(v0, v1, 1)
-                val e02 = graph.addEdge(v0, v2, 10)
+                val eva01 = graph.addEdge(v0, v1, 1)
+                val eva02 = graph.addEdge(v0, v2, 10)
                 val e23 = graph.addEdge(v2, v3, 0)
                 val e24 = graph.addEdge(v2, v4, -20)
 
-                val expectedResult = setOf(e24, e23, e01, e02)
+                val expectedResult = setOf(e24, e23, eva01, eva02)
                 val actualResult = graph.findMinSpanningTree().toSet()
 
                 assertEquals(expectedResult, actualResult)
@@ -412,10 +410,8 @@ class WeightedUndirectedGraphTest {
 
             @Test
             fun `if graph has no edges`() {
-                graph.apply {
-                    addVertex(0)
-                    addVertex(1)
-                }
+                graph.addVertex(0)
+                graph.addVertex(1)
 
                 val expectedResult = listOf<Edge<Int>>()
                 val actualResult = graph.findMinSpanningTree()
@@ -497,10 +493,8 @@ class WeightedUndirectedGraphTest {
                 val v1 = graph.addVertex(1)
                 val v2 = graph.addVertex(2)
 
-                graph.apply {
-                    addEdge(v0, v1, 1)
-                    addEdge(v0, v2, -1)
-                }
+                graph.addEdge(v0, v1, 1)
+                graph.addEdge(v0, v2, -1)
 
                 val actualResult = graph.findKeyVertices()
 

--- a/app/src/test/kotlin/model/abstractGraph/GraphTest.kt
+++ b/app/src/test/kotlin/model/abstractGraph/GraphTest.kt
@@ -3,9 +3,9 @@ package model.abstractGraph
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Nested
 import util.annotations.TestAllGraphTypes
-import util.setupAbstractGraph
 import util.emptyEdgesSet
 import util.emptyGraph
+import util.setupAbstractGraph
 
 class GraphTest {
     @Nested
@@ -218,12 +218,7 @@ class GraphTest {
                     val newV2 = newVertices[2]
                     val newV3 = newVertices[3]
 
-                    assertTrue(
-                        newV0 == oldV0 &&
-                        newV1 == oldV1 &&
-                        newV2.id == 2 && newV2.data == 4 &&
-                        newV3 == oldV3
-                    )
+                    assertTrue(newV0 == oldV0 && newV1 == oldV1 && newV2.id == 2 && newV2.data == 4 && newV3 == oldV3)
                 }
 
                 @TestAllGraphTypes
@@ -247,12 +242,13 @@ class GraphTest {
                     val newV3 = newVertices[3]
 
                     val actualEdges = graph.getEdges().toSet()
-                    val expectedEdges = setOf(
-                        graph.getEdge(newV0, newV1),
-                        graph.getEdge(newV3, newV2),
-                        graph.getEdge(newV2, newV1),
-                        graph.getEdge(newV3, newV1)
-                    )
+                    val expectedEdges =
+                        setOf(
+                            graph.getEdge(newV0, newV1),
+                            graph.getEdge(newV3, newV2),
+                            graph.getEdge(newV2, newV1),
+                            graph.getEdge(newV3, newV1)
+                        )
 
                     assertEquals(expectedEdges, actualEdges)
                 }
@@ -264,7 +260,7 @@ class GraphTest {
             @TestAllGraphTypes
             fun `removing vertex from an empty graph should cause exception`(graph: Graph<Int>) {
                 assertThrows(NoSuchElementException::class.java) {
-                    graph.removeVertex(Vertex(0,0))
+                    graph.removeVertex(Vertex(0, 0))
                 }
             }
 
@@ -273,7 +269,7 @@ class GraphTest {
                 setupAbstractGraph(graph)
 
                 assertThrows(NoSuchElementException::class.java) {
-                    graph.removeVertex(Vertex(1904,-360))
+                    graph.removeVertex(Vertex(1904, -360))
                 }
             }
 
@@ -282,7 +278,7 @@ class GraphTest {
                 setupAbstractGraph(graph)
 
                 assertThrows(NoSuchElementException::class.java) {
-                    graph.removeVertex(Vertex(6,3))
+                    graph.removeVertex(Vertex(6, 3))
                 }
             }
 
@@ -291,7 +287,7 @@ class GraphTest {
                 setupAbstractGraph(graph)
 
                 assertThrows(NoSuchElementException::class.java) {
-                    graph.removeVertex(Vertex(0,35))
+                    graph.removeVertex(Vertex(0, 35))
                 }
             }
         }


### PR DESCRIPTION
Add unit tests for `findKeyVertices()` algorithm of every graph.

Refactor unit tests: delete redundant code, apply same code style.